### PR TITLE
Initialize basic authentication scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # takip-muhasebe
+
 Precad Medya Çokkiracılı, abonelik tabanlı, hizmet takip ve muhasebe sistemi.
+
+Bu depo, sistemin ilk aşaması için temel giriş/kayıt altyapısını içerir.
+
+## Kurulum
+
+1. **Veritabanı oluşturma**
+   ```bash
+   mysql -u root -p < app/sql/schema.sql
+   ```
+2. **Veritabanı ayarları**
+   - `app/config/config.php` dosyasındaki veritabanı bilgilerini kendi ortamınıza göre güncelleyin.
+
+3. **PHP yerel sunucu çalıştırma**
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+4. Tarayıcıda `http://localhost:8000` adresine giderek giriş/kayıt işlemlerini yapabilirsiniz.
+
+## Gereksinimler
+- PHP 8+
+- MySQL 5.7+
+
+## Dizim Yapısı
+```
+app/
+  config/        Veritabanı bağlantısı
+  includes/      Ortak header, footer, menü
+  sql/           Veritabanı şeması
+public/
+  css/           Stil dosyaları
+  login.php      Giriş sayfası
+  register.php   Kayıt sayfası
+  dashboard.php  Giriş sonrası panel
+  logout.php     Çıkış
+```
+
+## Güvenlik Notları
+- PDO ve hazırlıklı ifadeler kullanılarak SQL injection önlenir.
+- Parolalar `password_hash` ve `password_verify` ile saklanır.
+- Oturum açmada `session_regenerate_id` kullanılır.
+
+Bu yapı ilerleyen aşamalarda yönetim paneli ve diğer modüllerle genişletilecektir.

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Database connection file.
+ * Returns a PDO instance for database interactions.
+ */
+$config = [
+    'host'    => 'localhost',        // MySQL host
+    'dbname'  => 'takip_muhasebe',   // Database name
+    'user'    => 'root',             // Database username
+    'pass'    => '',                 // Database password
+    'charset' => 'utf8mb4',          // Character set
+];
+
+$dsn = "mysql:host={$config['host']};dbname={$config['dbname']};charset={$config['charset']}";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $config['user'], $config['pass'], $options);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . $e->getMessage());
+}
+
+return $pdo;

--- a/app/includes/footer.php
+++ b/app/includes/footer.php
@@ -1,0 +1,17 @@
+</div> <!-- container -->
+<footer class="text-center mt-5 mb-3 text-muted">
+    &copy; <?php echo date('Y'); ?> Takip Muhasebe
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+// Simple dark/light mode toggle
+const toggle = document.getElementById('themeToggle');
+if(toggle){
+  toggle.addEventListener('click', () => {
+    const html = document.documentElement;
+    html.dataset.bsTheme = html.dataset.bsTheme === 'dark' ? 'light' : 'dark';
+  });
+}
+</script>
+</body>
+</html>

--- a/app/includes/header.php
+++ b/app/includes/header.php
@@ -1,0 +1,18 @@
+<?php
+// Start session if not already started
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+?>
+<!DOCTYPE html>
+<html lang="tr" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Takip Muhasebe</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+<?php include __DIR__ . '/menu.php'; ?>
+<div class="container mt-4">

--- a/app/includes/menu.php
+++ b/app/includes/menu.php
@@ -1,0 +1,21 @@
+<?php $loggedIn = isset($_SESSION['user_id']); ?>
+<nav class="navbar navbar-expand-lg bg-body-tertiary">
+  <div class="container">
+    <a class="navbar-brand" href="/dashboard.php">Takip Muhasebe</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+        <?php if($loggedIn): ?>
+          <li class="nav-item"><a class="nav-link" href="/dashboard.php">Dashboard</a></li>
+          <li class="nav-item"><a class="nav-link" href="/logout.php">Çıkış</a></li>
+        <?php else: ?>
+          <li class="nav-item"><a class="nav-link" href="/login.php">Giriş</a></li>
+          <li class="nav-item"><a class="nav-link" href="/register.php">Kayıt Ol</a></li>
+        <?php endif; ?>
+        <li class="nav-item"><button class="btn btn-sm btn-outline-secondary ms-3" id="themeToggle" type="button">Tema</button></li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/app/sql/schema.sql
+++ b/app/sql/schema.sql
@@ -1,0 +1,37 @@
+-- Database schema for takip-muhasebe system
+-- Use utf8mb4 character set
+
+CREATE DATABASE IF NOT EXISTS takip_muhasebe CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE takip_muhasebe;
+
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(150) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('admin', 'user') DEFAULT 'user',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Services table
+CREATE TABLE IF NOT EXISTS services (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    service_name VARCHAR(150) NOT NULL,
+    description TEXT,
+    price DECIMAL(10,2) NOT NULL,
+    period ENUM('ay','gun') NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Subscriptions table
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    user_id INT UNSIGNED NOT NULL,
+    service_id INT UNSIGNED NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    status ENUM('active','inactive','cancelled') DEFAULT 'active',
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_service FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,13 @@
+/* Custom styles */
+body {
+    transition: background-color 0.3s, color 0.3s;
+}
+
+.navbar-brand {
+    font-weight: bold;
+}
+
+form {
+    max-width: 400px;
+    margin: 0 auto;
+}

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -1,0 +1,14 @@
+<?php
+// Dashboard - require login
+$pdo = require __DIR__ . '/../app/config/config.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /login.php');
+    exit;
+}
+
+include __DIR__ . '/../app/includes/header.php';
+?>
+<h2>Dashboard</h2>
+<p>Hoş geldiniz, <?= htmlspecialchars($_SESSION['user_name'] ?? '') ?>!</p>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/public/login.php
+++ b/public/login.php
@@ -1,0 +1,47 @@
+<?php
+// Login script
+$pdo = require __DIR__ . '/../app/config/config.php';
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+    $password = $_POST['password'] ?? '';
+
+    if ($email && $password) {
+        $stmt = $pdo->prepare('SELECT id, name, password, role FROM users WHERE email = :email');
+        $stmt->execute(['email' => $email]);
+        $user = $stmt->fetch();
+        if ($user && password_verify($password, $user['password'])) {
+            session_regenerate_id(true);
+            $_SESSION['user_id'] = $user['id'];
+            $_SESSION['user_name'] = $user['name'];
+            $_SESSION['user_role'] = $user['role'];
+            header('Location: /dashboard.php');
+            exit;
+        } else {
+            $error = 'Geçersiz e-posta veya şifre';
+        }
+    } else {
+        $error = 'Lütfen tüm alanları doldurun';
+    }
+}
+
+include __DIR__ . '/../app/includes/header.php';
+?>
+<h2>Giriş</h2>
+<?php if ($error): ?>
+<div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+<?php endif; ?>
+<form method="post" action="">
+  <div class="mb-3">
+    <label for="email" class="form-label">E-posta</label>
+    <input type="email" class="form-control" name="email" id="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Şifre</label>
+    <input type="password" class="form-control" name="password" id="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary w-100">Giriş Yap</button>
+</form>
+<p class="mt-3 text-center"><a href="/register.php">Kayıt Ol</a></p>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/public/logout.php
+++ b/public/logout.php
@@ -1,0 +1,14 @@
+<?php
+// Logout script
+session_start();
+$_SESSION = [];
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000,
+        $params['path'], $params['domain'],
+        $params['secure'], $params['httponly']
+    );
+}
+session_destroy();
+header('Location: /login.php');
+exit;

--- a/public/register.php
+++ b/public/register.php
@@ -1,0 +1,59 @@
+<?php
+// Registration script
+$pdo = require __DIR__ . '/../app/config/config.php';
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim(filter_input(INPUT_POST, 'name', FILTER_SANITIZE_SPECIAL_CHARS));
+    $email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+    $password = $_POST['password'] ?? '';
+    $confirm  = $_POST['confirm'] ?? '';
+
+    if ($name && $email && $password && $confirm) {
+        if ($password !== $confirm) {
+            $error = 'Şifreler eşleşmiyor';
+        } else {
+            $stmt = $pdo->prepare('SELECT id FROM users WHERE email = :email');
+            $stmt->execute(['email' => $email]);
+            if ($stmt->fetch()) {
+                $error = 'Bu e-posta zaten kayıtlı';
+            } else {
+                $hash = password_hash($password, PASSWORD_BCRYPT);
+                $stmt = $pdo->prepare('INSERT INTO users (name, email, password) VALUES (:name, :email, :password)');
+                $stmt->execute(['name' => $name, 'email' => $email, 'password' => $hash]);
+                header('Location: /login.php');
+                exit;
+            }
+        }
+    } else {
+        $error = 'Lütfen tüm alanları doldurun';
+    }
+}
+
+include __DIR__ . '/../app/includes/header.php';
+?>
+<h2>Kayıt Ol</h2>
+<?php if ($error): ?>
+<div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+<?php endif; ?>
+<form method="post" action="">
+  <div class="mb-3">
+    <label for="name" class="form-label">Adınız</label>
+    <input type="text" class="form-control" name="name" id="name" required>
+  </div>
+  <div class="mb-3">
+    <label for="email" class="form-label">E-posta</label>
+    <input type="email" class="form-control" name="email" id="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Şifre</label>
+    <input type="password" class="form-control" name="password" id="password" required>
+  </div>
+  <div class="mb-3">
+    <label for="confirm" class="form-label">Şifre Tekrar</label>
+    <input type="password" class="form-control" name="confirm" id="confirm" required>
+  </div>
+  <button type="submit" class="btn btn-success w-100">Kayıt Ol</button>
+</form>
+<p class="mt-3 text-center"><a href="/login.php">Giriş Yap</a></p>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- set up PDO-based config and database schema
- add registration, login, dashboard and logout pages
- implement Bootstrap UI with dark/light toggle

## Testing
- `php -l public/dashboard.php`
- `php -l public/login.php`
- `php -l public/register.php`
- `php -l public/logout.php`
- `php -l app/includes/header.php`
- `php -l app/includes/menu.php`
- `php -l app/includes/footer.php`
- `php -l app/config/config.php`


------
https://chatgpt.com/codex/tasks/task_e_689f4e8b00cc8333b8f0379f1ad32831