### PR TITLE
Add role-based admin and firm panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # takip-muhasebe
+
 Precad Medya Çokkiracılı, abonelik tabanlı, hizmet takip ve muhasebe sistemi.
+
+Bu depo, sistemin ilk aşaması için rol tabanlı giriş/kayıt altyapısını içerir. Kayıt olan kullanıcılar "firma" rolünde oluşturulur ve varsayılan hizmet için abonelik başlatılır. Yönetici (admin) kullanıcıları veritabanından manuel ekleyebilirsiniz.
+
+## Kurulum
+
+1. **Veritabanı oluşturma**
+   ```bash
+   mysql -u root -p < app/sql/schema.sql
+   ```
+2. **Veritabanı ayarları**
+   - `app/config/config.php` dosyasındaki veritabanı bilgilerini kendi ortamınıza göre güncelleyin.
+
+3. **PHP yerel sunucu çalıştırma**
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+4. Tarayıcıda `http://localhost:8000` adresine giderek giriş/kayıt işlemlerini yapabilirsiniz. Giriş sonrası rolünüze göre ilgili panele yönlendirilirsiniz.
+
+## Gereksinimler
+- PHP 8+
+- MySQL 5.7+
+
+## Dizim Yapısı
+```
+app/
+  config/        Veritabanı bağlantısı
+  includes/      Ortak header, footer, menü
+  sql/           Veritabanı şeması
+admin/            Yönetici paneli
+firma/            Firma paneli
+public/
+  css/           Stil dosyaları
+  login.php      Giriş sayfası
+  register.php   Kayıt sayfası
+  dashboard.php  Rol bazlı yönlendirme
+  logout.php     Çıkış
+```
+
+## Güvenlik Notları
+- PDO ve hazırlıklı ifadeler kullanılarak SQL injection önlenir.
+- Parolalar `password_hash` ve `password_verify` ile saklanır.
+- Oturum açmada `session_regenerate_id` kullanılır.
+
+Bu yapı ilerleyen aşamalarda yönetim paneli ve diğer modüllerle genişletilecektir.

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,45 @@
+<?php
+session_start(); // ensure session is available
+$pdo = require __DIR__ . '/../app/config/config.php';
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    header('Location: /login.php');
+    exit;
+}
+// Mark expired subscriptions
+$pdo->exec("UPDATE subscriptions SET status='expired' WHERE end_date < CURDATE() AND status='active'");
+$totalFirms = $pdo->query("SELECT COUNT(*) FROM users WHERE role='firma'")->fetchColumn();
+$activeSubs = $pdo->query("SELECT COUNT(*) FROM subscriptions WHERE status='active'")->fetchColumn();
+$upcoming = $pdo->query("SELECT COUNT(*) FROM subscriptions WHERE status='active' AND end_date BETWEEN CURDATE() AND DATE_ADD(CURDATE(), INTERVAL 7 DAY)")->fetchColumn();
+include __DIR__ . '/../app/includes/header.php';
+include __DIR__ . '/../app/includes/sidebar.php';
+?>
+<div class="container mt-4">
+<h2>Admin Dashboard</h2>
+<div class="row">
+  <div class="col-md-4">
+    <div class="card text-bg-danger mb-3">
+      <div class="card-body">
+        <h5 class="card-title">Toplam Firma</h5>
+        <p class="card-text"><?= $totalFirms ?></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card text-bg-danger mb-3">
+      <div class="card-body">
+        <h5 class="card-title">Aktif Abonelik</h5>
+        <p class="card-text"><?= $activeSubs ?></p>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card text-bg-danger mb-3">
+      <div class="card-body">
+        <h5 class="card-title">Yaklaşan Bitişler (7g)</h5>
+        <p class="card-text"><?= $upcoming ?></p>
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/admin/firm_edit.php
+++ b/admin/firm_edit.php
@@ -1,0 +1,54 @@
+<?php
+session_start(); // ensure session available
+$pdo = require __DIR__ . '/../app/config/config.php';
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    header('Location: /login.php');
+    exit;
+}
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$id) {
+    header('Location: firms.php');
+    exit;
+}
+$stmt = $pdo->prepare("SELECT u.id,u.name,u.email,s.end_date FROM users u JOIN subscriptions s ON s.user_id=u.id WHERE u.id=:id");
+$stmt->execute(['id'=>$id]);
+$firm = $stmt->fetch();
+if (!$firm) {
+    header('Location: firms.php');
+    exit;
+}
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+    $name = trim($_POST['name']);
+    $email = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
+    $end = $_POST['end_date'];
+    if ($name && $email && $end) {
+        $upd = $pdo->prepare("UPDATE users SET name=:n,email=:e WHERE id=:id");
+        $upd->execute(['n'=>$name,'e'=>$email,'id'=>$id]);
+        $upd2 = $pdo->prepare("UPDATE subscriptions SET end_date=:end WHERE user_id=:id");
+        $upd2->execute(['end'=>$end,'id'=>$id]);
+        header('Location: firms.php');
+        exit;
+    }
+}
+include __DIR__ . '/../app/includes/header.php';
+include __DIR__ . '/../app/includes/sidebar.php';
+?>
+<div class="container mt-4">
+<h2>Firma Düzenle</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ad</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($firm['name']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">E-posta</label>
+    <input type="email" name="email" class="form-control" value="<?= htmlspecialchars($firm['email']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Abonelik Bitiş</label>
+    <input type="date" name="end_date" class="form-control" value="<?= $firm['end_date'] ?>" required>
+  </div>
+  <button class="btn btn-danger" type="submit">Kaydet</button>
+</form>
+</div>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/admin/firms.php
+++ b/admin/firms.php
@@ -1,0 +1,32 @@
+<?php
+session_start(); // ensure session started
+$pdo = require __DIR__ . '/../app/config/config.php';
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    header('Location: /login.php');
+    exit;
+}
+$stmt = $pdo->query("SELECT u.id, u.name, u.email, DATEDIFF(s.end_date, CURDATE()) AS kalan FROM users u JOIN subscriptions s ON s.user_id=u.id WHERE u.role='firma' AND s.status='active'");
+$firms = $stmt->fetchAll();
+include __DIR__ . '/../app/includes/header.php';
+include __DIR__ . '/../app/includes/sidebar.php';
+?>
+<div class="container mt-4">
+<h2>Firmalar</h2>
+<table class="table table-striped">
+  <thead>
+    <tr><th>ID</th><th>İsim</th><th>E-posta</th><th>Kalan Gün</th><th>İşlem</th></tr>
+  </thead>
+  <tbody>
+    <?php foreach($firms as $f): ?>
+    <tr>
+      <td><?= $f['id'] ?></td>
+      <td><?= htmlspecialchars($f['name']) ?></td>
+      <td><?= htmlspecialchars($f['email']) ?></td>
+      <td><?= $f['kalan'] ?></td>
+      <td><a class="btn btn-sm btn-danger" href="firm_edit.php?id=<?= $f['id'] ?>">Düzenle</a></td>
+    </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>
+</div>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/admin/services.php
+++ b/admin/services.php
@@ -1,0 +1,80 @@
+<?php
+session_start(); // start session for access control
+$pdo = require __DIR__ . '/../app/config/config.php';
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'admin') {
+    header('Location: /login.php');
+    exit;
+}
+// Handle delete
+if (isset($_GET['delete'])) {
+    $id = (int)$_GET['delete'];
+    $del = $pdo->prepare('DELETE FROM services WHERE id=:id');
+    $del->execute(['id'=>$id]);
+    header('Location: services.php');
+    exit;
+}
+// Handle add/update
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['service_name']);
+    $desc = trim($_POST['description']);
+    $price = (float)$_POST['price'];
+    $period = $_POST['period'];
+    $id = $_POST['id'] ?? '';
+    if ($name && $price && in_array($period, ['ay','yil'])) {
+        if ($id) {
+            $upd = $pdo->prepare('UPDATE services SET service_name=:n, description=:d, price=:p, period=:per WHERE id=:id');
+            $upd->execute(['n'=>$name,'d'=>$desc,'p'=>$price,'per'=>$period,'id'=>$id]);
+        } else {
+            $ins = $pdo->prepare('INSERT INTO services (service_name, description, price, period) VALUES (:n,:d,:p,:per)');
+            $ins->execute(['n'=>$name,'d'=>$desc,'p'=>$price,'per'=>$period]);
+        }
+        header('Location: services.php');
+        exit;
+    }
+}
+$editService = null;
+if (isset($_GET['edit'])) {
+    $id = (int)$_GET['edit'];
+    $stmt = $pdo->prepare('SELECT * FROM services WHERE id=:id');
+    $stmt->execute(['id'=>$id]);
+    $editService = $stmt->fetch();
+}
+$services = $pdo->query('SELECT * FROM services')->fetchAll();
+include __DIR__ . '/../app/includes/header.php';
+include __DIR__ . '/../app/includes/sidebar.php';
+?>
+<div class="container mt-4">
+<h2>Hizmetler</h2>
+<table class="table table-striped">
+<thead><tr><th>ID</th><th>Ad</th><th>Fiyat</th><th>Dönem</th><th>İşlem</th></tr></thead>
+<tbody>
+<?php foreach($services as $s): ?>
+<tr>
+  <td><?= $s['id'] ?></td>
+  <td><?= htmlspecialchars($s['service_name']) ?></td>
+  <td><?= $s['price'] ?></td>
+  <td><?= $s['period'] ?></td>
+  <td>
+    <a class="btn btn-sm btn-danger" href="services.php?edit=<?= $s['id'] ?>">Düzenle</a>
+    <a class="btn btn-sm btn-outline-danger" href="services.php?delete=<?= $s['id'] ?>" onclick="return confirm('Silinsin mi?')">Sil</a>
+  </td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+<h3><?= $editService ? 'Hizmeti Güncelle' : 'Yeni Hizmet' ?></h3>
+<form method="post">
+  <input type="hidden" name="id" value="<?= $editService['id'] ?? '' ?>">
+  <div class="mb-3"><label class="form-label">Ad</label><input type="text" name="service_name" class="form-control" value="<?= htmlspecialchars($editService['service_name'] ?? '') ?>" required></div>
+  <div class="mb-3"><label class="form-label">Açıklama</label><textarea name="description" class="form-control"><?= htmlspecialchars($editService['description'] ?? '') ?></textarea></div>
+  <div class="mb-3"><label class="form-label">Fiyat</label><input type="number" step="0.01" name="price" class="form-control" value="<?= $editService['price'] ?? '' ?>" required></div>
+  <div class="mb-3"><label class="form-label">Dönem</label>
+    <select name="period" class="form-select">
+      <option value="ay" <?= (isset($editService['period']) && $editService['period']=='ay') ? 'selected' : '' ?>>Aylık</option>
+      <option value="yil" <?= (isset($editService['period']) && $editService['period']=='yil') ? 'selected' : '' ?>>Yıllık</option>
+    </select>
+  </div>
+  <button class="btn btn-danger" type="submit">Kaydet</button>
+</form>
+</div>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Database connection file.
+ * Returns a PDO instance for database interactions.
+ */
+$config = [
+    'host'    => 'localhost',        // MySQL host
+    'dbname'  => 'takip_muhasebe',   // Database name
+    'user'    => 'root',             // Database username
+    'pass'    => '',                 // Database password
+    'charset' => 'utf8mb4',          // Character set
+];
+
+$dsn = "mysql:host={$config['host']};dbname={$config['dbname']};charset={$config['charset']}";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $config['user'], $config['pass'], $options);
+} catch (PDOException $e) {
+    die('Database connection failed: ' . $e->getMessage());
+}
+
+return $pdo;

--- a/app/includes/footer.php
+++ b/app/includes/footer.php
@@ -1,0 +1,16 @@
+<footer class="text-center mt-5 mb-3 text-muted">
+    &copy; <?php echo date('Y'); ?> Takip Muhasebe
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+// Simple dark/light mode toggle
+const toggle = document.getElementById('themeToggle');
+if(toggle){
+  toggle.addEventListener('click', () => {
+    const html = document.documentElement;
+    html.dataset.bsTheme = html.dataset.bsTheme === 'dark' ? 'light' : 'dark';
+  });
+}
+</script>
+</body>
+</html>

--- a/app/includes/header.php
+++ b/app/includes/header.php
@@ -1,0 +1,16 @@
+<?php
+// Start session if not already started
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+?>
+<!DOCTYPE html>
+<html lang="tr" data-bs-theme="light">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Takip Muhasebe</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body class="<?php echo isset($_SESSION['role']) ? $_SESSION['role'] : ''; ?>">

--- a/app/includes/menu.php
+++ b/app/includes/menu.php
@@ -1,0 +1,21 @@
+<?php $loggedIn = isset($_SESSION['user_id']); ?>
+<nav class="navbar navbar-expand-lg bg-body-tertiary">
+  <div class="container">
+    <a class="navbar-brand" href="/dashboard.php">Takip Muhasebe</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+        <?php if($loggedIn): ?>
+          <li class="nav-item"><a class="nav-link" href="/dashboard.php">Dashboard</a></li>
+          <li class="nav-item"><a class="nav-link" href="/logout.php">Çıkış</a></li>
+        <?php else: ?>
+          <li class="nav-item"><a class="nav-link" href="/login.php">Giriş</a></li>
+          <li class="nav-item"><a class="nav-link" href="/register.php">Kayıt Ol</a></li>
+        <?php endif; ?>
+        <li class="nav-item"><button class="btn btn-sm btn-outline-secondary ms-3" id="themeToggle" type="button">Tema</button></li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/app/includes/sidebar.php
+++ b/app/includes/sidebar.php
@@ -1,0 +1,35 @@
+<?php
+// Responsive sidebar menu for logged in users
+$role = $_SESSION['role'] ?? '';
+if (!$role) {
+    return; // no sidebar if role not set
+}
+$themeClass = $role === 'admin' ? 'sidebar-admin' : 'sidebar-firma';
+$navBg = $role === 'admin' ? 'bg-danger' : 'bg-primary';
+?>
+<nav class="navbar navbar-expand <?php echo $navBg; ?> navbar-dark">
+  <div class="container-fluid">
+    <button class="btn btn-outline-light" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar">☰</button>
+    <a class="navbar-brand" href="#">Takip Muhasebe</a>
+    <a class="btn btn-outline-light" href="/logout.php">Çıkış</a>
+  </div>
+</nav>
+<div class="offcanvas offcanvas-start <?php echo $themeClass; ?> text-white" tabindex="-1" id="sidebar">
+  <div class="offcanvas-header">
+    <h5 class="offcanvas-title">Menü</h5>
+    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas"></button>
+  </div>
+  <div class="offcanvas-body">
+    <ul class="nav flex-column">
+      <?php if ($role === 'admin'): ?>
+        <li class="nav-item"><a class="nav-link text-white" href="/admin/dashboard.php">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="/admin/firms.php">Firmalar</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="/admin/services.php">Hizmetler</a></li>
+      <?php else: ?>
+        <li class="nav-item"><a class="nav-link text-white" href="/firma/dashboard.php">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="/firma/subscriptions.php">Aboneliklerim</a></li>
+        <li class="nav-item"><a class="nav-link text-white" href="/firma/profile.php">Profil</a></li>
+      <?php endif; ?>
+    </ul>
+  </div>
+</div>

--- a/app/sql/schema.sql
+++ b/app/sql/schema.sql
@@ -1,0 +1,42 @@
+-- Database schema for takip-muhasebe system
+-- Use utf8mb4 character set
+
+CREATE DATABASE IF NOT EXISTS takip_muhasebe CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE takip_muhasebe;
+
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(150) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('admin', 'firma') DEFAULT 'firma',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Services table
+CREATE TABLE IF NOT EXISTS services (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    service_name VARCHAR(150) NOT NULL,
+    description TEXT,
+    price DECIMAL(10,2) NOT NULL,
+    period ENUM('ay','yil') NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Default service
+INSERT INTO services (service_name, description, price, period)
+    VALUES ('Temel Hizmet', 'Varsayılan servis', 0, 'ay')
+    ON DUPLICATE KEY UPDATE service_name=VALUES(service_name);
+
+-- Subscriptions table
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    user_id INT UNSIGNED NOT NULL,
+    service_id INT UNSIGNED NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    status ENUM('active','expired') DEFAULT 'active',
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_service FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/firma/dashboard.php
+++ b/firma/dashboard.php
@@ -1,0 +1,30 @@
+<?php
+session_start(); // start session for role check
+$pdo = require __DIR__ . '/../app/config/config.php';
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'firma') {
+    header('Location: /login.php');
+    exit;
+}
+$pdo->prepare("UPDATE subscriptions SET status='expired' WHERE end_date < CURDATE() AND status='active' AND user_id=:uid")->execute(['uid'=>$_SESSION['user_id']]);
+$stmt = $pdo->prepare("SELECT s.end_date, DATEDIFF(s.end_date, CURDATE()) AS kalan, sv.service_name FROM subscriptions s JOIN services sv ON sv.id=s.service_id WHERE s.user_id=:uid AND s.status='active'");
+$stmt->execute(['uid'=>$_SESSION['user_id']]);
+$subs = $stmt->fetchAll();
+include __DIR__ . '/../app/includes/header.php';
+include __DIR__ . '/../app/includes/sidebar.php';
+?>
+<div class="container mt-4">
+<h2>Firma Dashboard</h2>
+<div class="row">
+<?php foreach($subs as $s): ?>
+  <div class="col-md-4">
+    <div class="card text-bg-primary mb-3">
+      <div class="card-body">
+        <h5 class="card-title"><?= htmlspecialchars($s['service_name']) ?></h5>
+        <p class="card-text">Kalan Gün: <?= $s['kalan'] ?></p>
+      </div>
+    </div>
+  </div>
+<?php endforeach; ?>
+</div>
+</div>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/firma/profile.php
+++ b/firma/profile.php
@@ -1,0 +1,55 @@
+<?php
+session_start(); // start session for profile access
+$pdo = require __DIR__ . '/../app/config/config.php';
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'firma') {
+    header('Location: /login.php');
+    exit;
+}
+$userId = $_SESSION['user_id'];
+$stmt = $pdo->prepare('SELECT name,email FROM users WHERE id=:id');
+$stmt->execute(['id'=>$userId]);
+$user = $stmt->fetch();
+$message = '';
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+    $name = trim($_POST['name']);
+    $email = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
+    if ($name && $email) {
+        $u = $pdo->prepare('UPDATE users SET name=:n,email=:e WHERE id=:id');
+        $u->execute(['n'=>$name,'e'=>$email,'id'=>$userId]);
+    }
+    if (!empty($_POST['new_password']) && $_POST['new_password'] === $_POST['confirm_password']) {
+        $hash = password_hash($_POST['new_password'], PASSWORD_BCRYPT);
+        $p = $pdo->prepare('UPDATE users SET password=:p WHERE id=:id');
+        $p->execute(['p'=>$hash,'id'=>$userId]);
+    }
+    $message = 'Bilgiler güncellendi';
+    $stmt->execute(['id'=>$userId]);
+    $user = $stmt->fetch();
+}
+include __DIR__ . '/../app/includes/header.php';
+include __DIR__ . '/../app/includes/sidebar.php';
+?>
+<div class="container mt-4">
+<h2>Profil</h2>
+<?php if($message): ?><div class="alert alert-success"><?= $message ?></div><?php endif; ?>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Ad</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($user['name']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">E-posta</label>
+    <input type="email" name="email" class="form-control" value="<?= htmlspecialchars($user['email']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Yeni Şifre</label>
+    <input type="password" name="new_password" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Yeni Şifre Tekrar</label>
+    <input type="password" name="confirm_password" class="form-control">
+  </div>
+  <button class="btn btn-primary" type="submit">Güncelle</button>
+</form>
+</div>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/firma/subscriptions.php
+++ b/firma/subscriptions.php
@@ -1,0 +1,30 @@
+<?php
+session_start(); // start session for subscription view
+$pdo = require __DIR__ . '/../app/config/config.php';
+if (!isset($_SESSION['user_id']) || ($_SESSION['role'] ?? '') !== 'firma') {
+    header('Location: /login.php');
+    exit;
+}
+$stmt = $pdo->prepare('SELECT sv.service_name, s.start_date, s.end_date, s.status FROM subscriptions s JOIN services sv ON sv.id=s.service_id WHERE s.user_id=:uid');
+$stmt->execute(['uid'=>$_SESSION['user_id']]);
+$subs = $stmt->fetchAll();
+include __DIR__ . '/../app/includes/header.php';
+include __DIR__ . '/../app/includes/sidebar.php';
+?>
+<div class="container mt-4">
+<h2>Aboneliklerim</h2>
+<table class="table table-striped">
+  <thead><tr><th>Hizmet</th><th>Başlangıç</th><th>Bitiş</th><th>Durum</th></tr></thead>
+  <tbody>
+    <?php foreach($subs as $s): ?>
+    <tr>
+      <td><?= htmlspecialchars($s['service_name']) ?></td>
+      <td><?= $s['start_date'] ?></td>
+      <td><?= $s['end_date'] ?></td>
+      <td><?= $s['status'] ?></td>
+    </tr>
+    <?php endforeach; ?>
+  </tbody>
+</table>
+</div>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,27 @@
+/* Custom styles */
+body {
+    transition: background-color 0.3s, color 0.3s;
+}
+
+.navbar-brand {
+    font-weight: bold;
+}
+
+form {
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+/* Sidebar themes */
+.sidebar-admin {
+    background-color: #dc3545;
+}
+
+.sidebar-firma {
+    background-color: #0d6efd;
+}
+
+.sidebar-admin .nav-link,
+.sidebar-firma .nav-link {
+    color: #fff;
+}

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -1,0 +1,22 @@
+<?php
+// Dashboard - require login
+session_start(); // access session data
+$pdo = require __DIR__ . '/../app/config/config.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /login.php');
+    exit;
+}
+
+if ($_SESSION['role'] === 'admin') {
+    header('Location: /admin/dashboard.php');
+    exit;
+}
+
+if ($_SESSION['role'] === 'firma') {
+    header('Location: /firma/dashboard.php');
+    exit;
+}
+
+header('Location: /login.php');
+exit;

--- a/public/login.php
+++ b/public/login.php
@@ -1,0 +1,51 @@
+<?php
+// Login script
+session_start(); // start session before accessing $_SESSION
+$pdo = require __DIR__ . '/../app/config/config.php';
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+    $password = $_POST['password'] ?? '';
+
+    if ($email && $password) {
+        $stmt = $pdo->prepare('SELECT id, name, password, role FROM users WHERE email = :email');
+        $stmt->execute(['email' => $email]);
+        $user = $stmt->fetch();
+        if ($user && password_verify($password, $user['password'])) {
+            session_regenerate_id(true);
+            $_SESSION['user_id'] = $user['id'];
+            $_SESSION['user_name'] = $user['name'];
+            $_SESSION['role'] = $user['role'];
+            header('Location: /dashboard.php');
+            exit;
+        } else {
+            $error = 'Geçersiz e-posta veya şifre';
+        }
+    } else {
+        $error = 'Lütfen tüm alanları doldurun';
+    }
+}
+
+include __DIR__ . '/../app/includes/header.php';
+include __DIR__ . '/../app/includes/menu.php';
+?>
+<div class="container mt-4">
+<h2>Giriş</h2>
+<?php if ($error): ?>
+<div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+<?php endif; ?>
+<form method="post" action="">
+  <div class="mb-3">
+    <label for="email" class="form-label">E-posta</label>
+    <input type="email" class="form-control" name="email" id="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Şifre</label>
+    <input type="password" class="form-control" name="password" id="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary w-100">Giriş Yap</button>
+</form>
+<p class="mt-3 text-center"><a href="/register.php">Kayıt Ol</a></p>
+</div>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>

--- a/public/logout.php
+++ b/public/logout.php
@@ -1,0 +1,14 @@
+<?php
+// Logout script
+session_start();
+$_SESSION = [];
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000,
+        $params['path'], $params['domain'],
+        $params['secure'], $params['httponly']
+    );
+}
+session_destroy();
+header('Location: /login.php');
+exit;

--- a/public/register.php
+++ b/public/register.php
@@ -1,0 +1,81 @@
+<?php
+// Registration script
+$pdo = require __DIR__ . '/../app/config/config.php';
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim(filter_input(INPUT_POST, 'name', FILTER_SANITIZE_SPECIAL_CHARS));
+    $email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+    $password = $_POST['password'] ?? '';
+    $confirm  = $_POST['confirm'] ?? '';
+    $period = $_POST['period'] ?? 'ay';
+    // accept only allowed periods
+    if (!in_array($period, ['ay','yil'], true)) {
+        $period = 'ay';
+    }
+
+    if ($name && $email && $password && $confirm) {
+        if ($password !== $confirm) {
+            $error = 'Şifreler eşleşmiyor';
+        } else {
+            $stmt = $pdo->prepare('SELECT id FROM users WHERE email = :email');
+            $stmt->execute(['email' => $email]);
+            if ($stmt->fetch()) {
+                $error = 'Bu e-posta zaten kayıtlı';
+            } else {
+                $hash = password_hash($password, PASSWORD_BCRYPT);
+                $pdo->beginTransaction();
+                $stmt = $pdo->prepare('INSERT INTO users (name, email, password, role) VALUES (:name, :email, :password, :role)');
+                $stmt->execute(['name' => $name, 'email' => $email, 'password' => $hash, 'role' => 'firma']);
+                $userId = $pdo->lastInsertId();
+                $start = date('Y-m-d');
+                $end = date('Y-m-d', strtotime($period === 'yil' ? '+1 year' : '+1 month'));
+                $sub = $pdo->prepare('INSERT INTO subscriptions (user_id, service_id, start_date, end_date, status) VALUES (:uid, :sid, :start, :end, :status)');
+                $sub->execute(['uid' => $userId, 'sid' => 1, 'start' => $start, 'end' => $end, 'status' => 'active']);
+                $pdo->commit();
+                header('Location: /login.php');
+                exit;
+            }
+        }
+    } else {
+        $error = 'Lütfen tüm alanları doldurun';
+    }
+}
+
+include __DIR__ . '/../app/includes/header.php';
+include __DIR__ . '/../app/includes/menu.php';
+?>
+<div class="container mt-4">
+<h2>Kayıt Ol</h2>
+<?php if ($error): ?>
+<div class="alert alert-danger"><?= htmlspecialchars($error) ?></div>
+<?php endif; ?>
+<form method="post" action="">
+  <div class="mb-3">
+    <label for="name" class="form-label">Adınız</label>
+    <input type="text" class="form-control" name="name" id="name" required>
+  </div>
+  <div class="mb-3">
+    <label for="email" class="form-label">E-posta</label>
+    <input type="email" class="form-control" name="email" id="email" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Şifre</label>
+    <input type="password" class="form-control" name="password" id="password" required>
+  </div>
+  <div class="mb-3">
+    <label for="confirm" class="form-label">Şifre Tekrar</label>
+    <input type="password" class="form-control" name="confirm" id="confirm" required>
+  </div>
+  <div class="mb-3">
+    <label for="period" class="form-label">Kiralama Tipi</label>
+    <select name="period" id="period" class="form-select">
+      <option value="ay">Aylık</option>
+      <option value="yil">Yıllık</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-success w-100">Kayıt Ol</button>
+</form>
+<p class="mt-3 text-center"><a href="/login.php">Giriş Yap</a></p>
+</div>
+<?php include __DIR__ . '/../app/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- extend schema with admin/firma roles and default service
- add subscription-backed registration with period selection
- introduce sidebar-driven admin and firm dashboards with management pages
- start sessions before role checks and sanitize subscription period input

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n 1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689f4e8b00cc8333b8f0379f1ad32831