### PR TITLE
Kullanıcı kimlik doğrulama ve kayıt sistemi

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+APP_URL=http://localhost
+DB_HOST=localhost
+DB_NAME=dbname
+DB_USER=dbuser
+DB_PASS=dbpass
+SMTP_HOST=localhost
+SMTP_PORT=587
+SMTP_USER=null
+SMTP_PASS=null
+TIMEZONE=Europe/Istanbul

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,5 @@
+Options -Indexes
+DirectoryIndex index.php
+<FilesMatch "(\.env|schema\.sql|seed\.sql|config\.php|composer\.(json|lock))">
+    Require all denied
+</FilesMatch>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# takip-muhasebe
-Precad Medya Çokkiracılı, abonelik tabanlı, hizmet takip ve muhasebe sistemi.
+# Çokkiracılı Takip/Muhasebe
+
+cPanel/Shared hosting üzerinde çalışacak basit çokkiracılı takip ve muhasebe uygulaması.
+
+## Kurulum
+1. PHP 8.1+ ve pdo_mysql, mbstring, intl, curl, json, zip, gd, fileinfo eklentilerinin aktif olduğundan emin olun.
+2. MySQL'de bir veritabanı ve kullanıcı oluşturup yetkilerini verin.
+3. phpMyAdmin'de hedef veritabanını seçin ve `app/sql/schema.sql` ardından `app/sql/seed.sql` dosyalarını içe aktarın.
+4. `app/config/.env` dosyasını oluşturup `.env.example` içeriğine göre düzenleyin.
+5. (Opsiyonel) Cron görevleri için `app/cron/*.php` dosyalarını zamanlayıcıya ekleyin.
+
+## İlk Giriş Bilgileri
+- Yönetici: `admin@example.com` / `Admin123!`
+- Firma: `info@precadmedya.com.tr` / `123456`
+
+Güvenlik sebebiyle ilk girişten sonra parolaları değiştiriniz.

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,31 @@
+<?php
+require __DIR__.'/../app/config/config.php';
+require __DIR__.'/../app/config/auth.php';
+require __DIR__.'/../app/config/rbac.php';
+if(!isYonetici()) { header('Location: /login.php'); exit; }
+$active = $pdo->query("SELECT COUNT(*) FROM firms WHERE status='active'")->fetchColumn();
+$renew = $pdo->query("SELECT COUNT(*) FROM firm_subscriptions WHERE end_date = CURDATE()")->fetchColumn();
+$suspended = $pdo->query("SELECT COUNT(*) FROM firms WHERE status='suspended'")->fetchColumn();
+include __DIR__.'/../partials/header.php';
+?>
+<div class="row g-4">
+  <div class="col-md-4">
+    <div class="card text-center p-3">
+      <h5>Aktif Firmalar</h5>
+      <p class="display-6"><?php echo $active; ?></p>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card text-center p-3">
+      <h5>Bugün Yenilenecek</h5>
+      <p class="display-6"><?php echo $renew; ?></p>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card text-center p-3">
+      <h5>Askıdaki Firmalar</h5>
+      <p class="display-6"><?php echo $suspended; ?></p>
+    </div>
+  </div>
+</div>
+<?php include __DIR__.'/../partials/footer.php'; ?>

--- a/app/config/auth.php
+++ b/app/config/auth.php
@@ -1,0 +1,32 @@
+<?php
+if(session_status() === PHP_SESSION_NONE) session_start();
+function login(PDO $pdo, string $email, string $password) {
+    $stmt = $pdo->prepare("SELECT u.*, f.name AS firm_name FROM users u LEFT JOIN firms f ON u.firm_id=f.id WHERE u.email=? LIMIT 1");
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+    if(!$user || !$user['is_active']) {
+        return 'Geçersiz kullanıcı';
+    }
+    if($user['failed_attempts'] >= 5 && strtotime($user['updated_at']) > time()-900) {
+        return 'Hesap geçici olarak kilitli';
+    }
+    if(!password_verify($password, $user['password_hash'])) {
+        $pdo->prepare("UPDATE users SET failed_attempts = failed_attempts + 1, updated_at=NOW() WHERE id=?")->execute([$user['id']]);
+        return 'Hatalı giriş';
+    }
+    $pdo->prepare("UPDATE users SET failed_attempts=0, last_login_at=NOW(), updated_at=NOW() WHERE id=?")->execute([$user['id']]);
+    session_regenerate_id(true);
+    $_SESSION['user'] = [
+        'id' => $user['id'],
+        'role' => $user['role'],
+        'full_name' => $user['full_name'],
+        'firm_id' => $user['firm_id'],
+        'firm_name' => $user['firm_name']
+    ];
+    return true;
+}
+function logout(): void {
+    if(session_status() === PHP_SESSION_NONE) session_start();
+    $_SESSION = [];
+    session_destroy();
+}

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__.'/env.php';
+if(session_status() === PHP_SESSION_NONE) session_start();
+$timezone = env('TIMEZONE','Europe/Istanbul');
+if(function_exists('date_default_timezone_set')) {
+    date_default_timezone_set($timezone);
+}
+$dsn = 'mysql:host='.env('DB_HOST','localhost').';dbname='.env('DB_NAME','').';charset=utf8mb4';
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES => false,
+];
+try {
+    $pdo = new PDO($dsn, env('DB_USER',''), env('DB_PASS',''), $options);
+} catch (PDOException $e) {
+    die('Veritabanına bağlanılamadı.');
+}

--- a/app/config/csrf.php
+++ b/app/config/csrf.php
@@ -1,0 +1,19 @@
+<?php
+if(session_status() === PHP_SESSION_NONE) session_start();
+function csrf_token(): string {
+    if(empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+function csrf_field(): string {
+    return '<input type="hidden" name="csrf_token" value="'.csrf_token().'">';
+}
+function verify_csrf(): void {
+    if($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $token = $_POST['csrf_token'] ?? '';
+        if(!hash_equals($_SESSION['csrf_token'] ?? '', $token)) {
+            die('CSRF doğrulaması başarısız');
+        }
+    }
+}

--- a/app/config/env.php
+++ b/app/config/env.php
@@ -1,0 +1,16 @@
+<?php
+function env(string $key, $default=null) {
+    static $vars = null;
+    if($vars === null) {
+        $path = __DIR__.'/.env';
+        $vars = [];
+        if(file_exists($path)) {
+            foreach(file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+                if(str_starts_with(trim($line),'#') || !str_contains($line,'=')) continue;
+                [$k,$v] = explode('=', $line, 2);
+                $vars[trim($k)] = trim($v);
+            }
+        }
+    }
+    return $vars[$key] ?? $default;
+}

--- a/app/config/rbac.php
+++ b/app/config/rbac.php
@@ -1,0 +1,8 @@
+<?php
+if(session_status() === PHP_SESSION_NONE) session_start();
+function isYonetici(): bool {
+    return ($_SESSION['user']['role'] ?? '') === 'yonetici';
+}
+function isFirma(): bool {
+    return ($_SESSION['user']['role'] ?? '') === 'firma';
+}

--- a/app/config/subscription_guard.php
+++ b/app/config/subscription_guard.php
@@ -1,0 +1,16 @@
+<?php
+function checkSubscription(PDO $pdo, int $firmId): array {
+    $stmt = $pdo->prepare("SELECT *, DATEDIFF(end_date, CURDATE()) as days_left FROM firm_subscriptions WHERE firm_id=? ORDER BY end_date DESC LIMIT 1");
+    $stmt->execute([$firmId]);
+    $sub = $stmt->fetch();
+    if(!$sub) return ['status'=>'missing','days_left'=>0];
+    $today = new DateTime();
+    $end = new DateTime($sub['end_date']);
+    $grace = (clone $end)->modify('+'.$sub['grace_days'].' day');
+    if($today <= $end) {
+        return ['status'=>'active','days_left'=>$sub['days_left']];
+    } elseif($today <= $grace) {
+        return ['status'=>'grace','days_left'=>$today->diff($grace)->days];
+    }
+    return ['status'=>'expired','days_left'=>0];
+}

--- a/app/config/tenant_middleware.php
+++ b/app/config/tenant_middleware.php
@@ -1,0 +1,7 @@
+<?php
+if(session_status() === PHP_SESSION_NONE) session_start();
+function requireFirm(int $firmId): void {
+    if(($_SESSION['user']['role'] ?? '') === 'firma' && $_SESSION['user']['firm_id'] != $firmId) {
+        die('Yetkisiz erişim');
+    }
+}

--- a/app/cron/exchange_rates_cron.php
+++ b/app/cron/exchange_rates_cron.php
@@ -1,0 +1,2 @@
+<?php
+// TODO: Döviz kurlarını güncelleme cron'u

--- a/app/cron/reminder_cron.php
+++ b/app/cron/reminder_cron.php
@@ -1,0 +1,2 @@
+<?php
+// TODO: Hatırlatma e-postaları cron'u

--- a/app/lib/logger.php
+++ b/app/lib/logger.php
@@ -1,0 +1,11 @@
+<?php
+class Logger {
+    protected string $file;
+    public function __construct(string $file) {
+        $this->file = $file;
+    }
+    public function info(string $message): void {
+        $date = date('Y-m-d H:i:s');
+        file_put_contents($this->file, "[$date] $message\n", FILE_APPEND);
+    }
+}

--- a/app/sql/schema.sql
+++ b/app/sql/schema.sql
@@ -1,0 +1,89 @@
+-- Schema without CREATE DATABASE/USE
+SET NAMES utf8mb4;
+SET time_zone = '+00:00';
+
+CREATE TABLE firms (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  slug VARCHAR(255) NOT NULL UNIQUE,
+  email VARCHAR(255) NOT NULL,
+  phone VARCHAR(50) DEFAULT NULL,
+  address VARCHAR(255) DEFAULT NULL,
+  status ENUM('active','suspended','cancelled') DEFAULT 'active',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE users (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NULL,
+  role ENUM('yonetici','firma') DEFAULT 'firma',
+  full_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  is_active TINYINT(1) DEFAULT 1,
+  failed_attempts TINYINT UNSIGNED DEFAULT 0,
+  last_login_at DATETIME NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_users_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE settings (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NOT NULL UNIQUE,
+  brand_name VARCHAR(255) DEFAULT NULL,
+  logo_path VARCHAR(255) DEFAULT NULL,
+  theme_primary_color VARCHAR(7) DEFAULT '#1d4ed8',
+  currency_method ENUM('transaction_date','latest') DEFAULT 'latest',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_settings_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE services (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  service_name VARCHAR(255) NOT NULL UNIQUE,
+  description TEXT,
+  price DECIMAL(12,2) DEFAULT 0.00,
+  period ENUM('ay','yil') NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO services (service_name, description, price, period, created_at)
+VALUES ('Temel Hizmet','Varsayılan servis',0.00,'ay',NOW())
+ON DUPLICATE KEY UPDATE description=VALUES(description), price=VALUES(price), period=VALUES(period);
+
+CREATE TABLE firm_subscriptions (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NOT NULL,
+  service_id INT UNSIGNED NOT NULL,
+  plan ENUM('monthly','yearly') NOT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  status ENUM('active','expired','suspended') DEFAULT 'active',
+  auto_renew TINYINT(1) DEFAULT 0,
+  grace_days INT UNSIGNED DEFAULT 7,
+  last_payment_at DATETIME NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_firm_end (firm_id, end_date),
+  CONSTRAINT fk_subscription_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE CASCADE,
+  CONSTRAINT fk_subscription_service FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE audit_logs (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NULL,
+  user_id INT UNSIGNED NULL,
+  entity_type VARCHAR(64) NOT NULL,
+  entity_id BIGINT UNSIGNED NULL,
+  action ENUM('create','update','delete','login','logout') NOT NULL,
+  old_values JSON NULL,
+  new_values JSON NULL,
+  ip VARCHAR(45) NULL,
+  user_agent VARCHAR(255) NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_audit_firm (firm_id),
+  CONSTRAINT fk_audit_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE SET NULL,
+  CONSTRAINT fk_audit_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/app/sql/seed.sql
+++ b/app/sql/seed.sql
@@ -1,0 +1,17 @@
+INSERT INTO firms (name, slug, email, status, created_at, updated_at)
+VALUES ('Precad Medya','precad-medya','info@precadmedya.com.tr','active',NOW(),NOW());
+
+INSERT INTO settings (firm_id, brand_name, logo_path, theme_primary_color, currency_method, created_at, updated_at)
+VALUES (1,'Precad Medya',NULL,'#1d4ed8','latest',NOW(),NOW());
+
+INSERT INTO users (firm_id, role, full_name, email, password_hash, created_at, updated_at)
+VALUES
+(NULL,'yonetici','Sistem Yöneticisi','admin@example.com','$2y$12$e.91VviNoIn0DiWXboSNPuAQkkT.17tiNM9AhHWCVX8ENtxosREEC',NOW(),NOW()),
+(1,'firma','Precad Medya','info@precadmedya.com.tr','$2y$12$EF5FbbpY3cuTUkgLTwOT0.XzWl8OSQAKUZTu1qkay2ZLJgzVXXhyS',NOW(),NOW());
+
+INSERT INTO services (service_name, description, price, period, created_at)
+VALUES ('Temel Hizmet','Varsayılan servis',0.00,'ay',NOW())
+ON DUPLICATE KEY UPDATE description=VALUES(description), price=VALUES(price), period=VALUES(period);
+
+INSERT INTO firm_subscriptions (firm_id, service_id, plan, start_date, end_date, status, auto_renew, grace_days, created_at)
+VALUES (1,1,'monthly',CURDATE(),DATE_ADD(CURDATE(), INTERVAL 30 DAY),'active',1,7,NOW());

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,0 +1,21 @@
+body {
+  background-color: #f8f9fa;
+  color: #212529;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+}
+
+.navbar-brand img {
+  height: 40px;
+}
+
+.card {
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+  border-radius: 0.5rem;
+}
+
+.table thead {
+  background-color: #1d4ed8;
+  color: #fff;
+}
+
+/*# sourceMappingURL=theme.css.map */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,4 @@
+document.addEventListener('DOMContentLoaded', function(){
+  var toastElList = [].slice.call(document.querySelectorAll('.toast'));
+  toastElList.map(function(toastEl){ return new bootstrap.Toast(toastEl); }).forEach(t=>t.show());
+});

--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -1,0 +1,9 @@
+@import 'variables';
+body {
+  background-color: $body-bg;
+  color: $body-color;
+  font-family: $font-family-base;
+}
+.navbar-brand img { height: 40px; }
+.card { box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,.075); border-radius: .5rem; }
+.table thead { background-color: $primary; color: #fff; }

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -1,0 +1,4 @@
+$primary: #1d4ed8;
+$font-family-base: 'Helvetica Neue', Arial, sans-serif;
+$body-bg: #f8f9fa;
+$body-color: #212529;

--- a/assets/uploads/.htaccess
+++ b/assets/uploads/.htaccess
@@ -1,0 +1,2 @@
+php_flag engine off
+Options -ExecCGI

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+if(!isset($_SESSION['user_id'])) {
+    header('Location: /login.php');
+    exit;
+}
+include __DIR__.'/partials/header.php';
+?>
+<h1 class="mb-4">Hoş geldiniz, <?php echo htmlspecialchars($_SESSION['name']); ?>!</h1>
+<p>Rolünüz: <?php echo htmlspecialchars($_SESSION['role']); ?></p>
+<?php if($_SESSION['role'] === 'admin'): ?>
+    <a href="#" class="btn btn-primary">Servisleri Yönet</a>
+<?php else: ?>
+    <h5>Abonelikleriniz</h5>
+    <div class="alert alert-info">Henüz abonelik bulunmuyor.</div>
+<?php endif; ?>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/firma/dashboard.php
+++ b/firma/dashboard.php
@@ -1,0 +1,20 @@
+<?php
+require __DIR__.'/../app/config/config.php';
+require __DIR__.'/../app/config/auth.php';
+require __DIR__.'/../app/config/rbac.php';
+require __DIR__.'/../app/config/subscription_guard.php';
+if(!isFirma()) { header('Location: /login.php'); exit; }
+$sub = checkSubscription($pdo, $_SESSION['user']['firm_id']);
+include __DIR__.'/../partials/header.php';
+if($sub['status'] !== 'expired' && $sub['days_left'] <= 7) {
+    echo '<div class="alert alert-warning">Aboneliğiniz bitmek üzere...</div>';
+}
+?>
+<div class="mb-3">
+  <span class="badge bg-success">Kalan: <?php echo $sub['days_left']; ?> gün</span>
+</div>
+<div class="card p-4">
+  <h5>Yaklaşan Hizmetler</h5>
+  <p>Henüz bir veri yok.</p>
+</div>
+<?php include __DIR__.'/../partials/footer.php'; ?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+if(isset($_SESSION['user_id'])) {
+    header('Location: /dashboard.php');
+    exit;
+}
+include __DIR__.'/partials/header.php';
+?>
+<div class="text-center py-5">
+    <h1 class="mb-4">Takip / Muhasebe Sistemi</h1>
+    <p class="mb-4">Hoş geldiniz. Lütfen giriş yapın veya kayıt olun.</p>
+    <a class="btn btn-primary me-2" href="/login.php">Giriş</a>
+    <a class="btn btn-secondary" href="/register.php">Kayıt Ol</a>
+</div>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,53 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+session_start();
+if(isset($_SESSION['user_id'])) {
+    header('Location: /dashboard.php');
+    exit;
+}
+if($_SERVER['REQUEST_METHOD'] === 'POST') {
+    verify_csrf();
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $stmt = $pdo->prepare("SELECT u.id, u.full_name, u.password_hash, u.role, u.firm_id, f.name AS firm_name FROM users u LEFT JOIN firms f ON u.firm_id=f.id WHERE u.email = ? LIMIT 1");
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+    if($user && password_verify($password, $user['password_hash'])) {
+        session_regenerate_id(true);
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['role'] = $user['role'] === 'yonetici' ? 'admin' : 'firma';
+        $_SESSION['name'] = $user['full_name'];
+        $_SESSION['user'] = [
+            'id' => $user['id'],
+            'role' => $user['role'],
+            'full_name' => $user['full_name'],
+            'firm_id' => $user['firm_id'],
+            'firm_name' => $user['firm_name']
+        ];
+        header('Location: /dashboard.php');
+        exit;
+    } else {
+        $_SESSION['flash']['danger'] = 'Geçersiz e-posta veya parola';
+    }
+}
+include __DIR__.'/partials/header.php';
+?>
+<div class="row justify-content-center">
+    <div class="col-md-4">
+        <form method="post" class="card p-4">
+            <h3 class="mb-3">Giriş Yap</h3>
+            <?php echo csrf_field(); ?>
+            <div class="mb-3">
+                <label class="form-label">E-posta</label>
+                <input type="email" name="email" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Parola</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Giriş</button>
+        </form>
+    </div>
+</div>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+$_SESSION = [];
+session_destroy();
+header('Location: /login.php');
+exit;

--- a/partials/alerts.php
+++ b/partials/alerts.php
@@ -1,0 +1,8 @@
+<?php
+if(!empty($_SESSION['flash'])) {
+    foreach($_SESSION['flash'] as $type => $msg) {
+        echo '<div class="alert alert-' . $type . ' alert-dismissible fade show" role="alert">'.htmlspecialchars($msg).'<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>';
+    }
+    unset($_SESSION['flash']);
+}
+?>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,0 +1,6 @@
+<footer class="text-center mt-5 mb-3 text-muted">&copy; <?php echo date('Y'); ?> Takip Muhasebe</footer>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/assets/js/app.js"></script>
+</body>
+</html>

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,0 +1,36 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Takip Muhasebe</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/assets/css/theme.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container">
+        <a class="navbar-brand" href="/">Takip Muhasebe</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <?php if(isset($_SESSION['user_id'])): ?>
+                    <li class="nav-item"><a class="nav-link" href="/dashboard.php">Dashboard</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/logout.php">Çıkış</a></li>
+                <?php else: ?>
+                    <li class="nav-item"><a class="nav-link" href="/login.php">Giriş</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/register.php">Kayıt Ol</a></li>
+                <?php endif; ?>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div class="container">
+<?php include __DIR__.'/alerts.php'; ?>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,70 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+session_start();
+if(isset($_SESSION['user_id'])) {
+    header('Location: /dashboard.php');
+    exit;
+}
+if($_SERVER['REQUEST_METHOD'] === 'POST') {
+    verify_csrf();
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $confirm = $_POST['password_confirm'] ?? '';
+    if($password !== $confirm) {
+        $_SESSION['flash']['danger'] = 'Parolalar eşleşmiyor';
+    } else {
+        $stmt = $pdo->prepare("SELECT id FROM users WHERE email = ? LIMIT 1");
+        $stmt->execute([$email]);
+        if($stmt->fetch()) {
+            $_SESSION['flash']['danger'] = 'Bu e-posta zaten kayıtlı';
+        } else {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $stmt = $pdo->prepare("INSERT INTO users (full_name,email,password_hash,role) VALUES (?,?,?,?)");
+            $stmt->execute([$name,$email,$hash,'firma']);
+            $user_id = $pdo->lastInsertId();
+            session_regenerate_id(true);
+            $_SESSION['user_id'] = $user_id;
+            $_SESSION['role'] = 'firma';
+            $_SESSION['name'] = $name;
+            $_SESSION['user'] = [
+                'id' => $user_id,
+                'role' => 'firma',
+                'full_name' => $name,
+                'firm_id' => null,
+                'firm_name' => null
+            ];
+            header('Location: /dashboard.php');
+            exit;
+        }
+    }
+}
+include __DIR__.'/partials/header.php';
+?>
+<div class="row justify-content-center">
+    <div class="col-md-4">
+        <form method="post" class="card p-4">
+            <h3 class="mb-3">Kayıt Ol</h3>
+            <?php echo csrf_field(); ?>
+            <div class="mb-3">
+                <label class="form-label">Ad Soyad</label>
+                <input type="text" name="name" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">E-posta</label>
+                <input type="email" name="email" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Parola</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Parola (Tekrar)</label>
+                <input type="password" name="password_confirm" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-success w-100">Kayıt Ol</button>
+        </form>
+    </div>
+</div>
+<?php include __DIR__.'/partials/footer.php'; ?>


### PR DESCRIPTION
## Özellikler
- Karşılama sayfası ve kayıt formu eklenerek oturum açma akışı genişletildi
- Giriş ve kayıt işlemlerinde güvenli parola doğrulaması ve oturum yönetimi
- Dashboard ve navigasyon, oturum durumuna göre bağlantıları gösteriyor

## Kurulum
1. Gereken PHP 8.1+ ortamını ve MySQL şemasını önceki adımlardaki gibi kurun.
2. `app/config/.env` dosyası üzerinden veritabanı bağlantı bilgilerini sağlayın.
3. Tüm PHP dosyaları kök dizinden çalışacak şekilde sunucuya yükleyin.


------
https://chatgpt.com/codex/tasks/task_e_689f5746127c833388559d9ef21b5900