### PR TITLE
Müşteri ve ürün modülleri

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+APP_URL=http://localhost
+DB_HOST=localhost
+DB_NAME=dbname
+DB_USER=dbuser
+DB_PASS=dbpass
+SMTP_HOST=localhost
+SMTP_PORT=587
+SMTP_USER=null
+SMTP_PASS=null
+TIMEZONE=Europe/Istanbul

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,5 @@
+Options -Indexes
+DirectoryIndex index.php
+<FilesMatch "(\.env|schema\.sql|seed\.sql|config\.php|composer\.(json|lock))">
+    Require all denied
+</FilesMatch>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# takip-muhasebe
-Precad Medya Çokkiracılı, abonelik tabanlı, hizmet takip ve muhasebe sistemi.
+# Çokkiracılı Takip/Muhasebe
+
+cPanel/Shared hosting üzerinde çalışacak basit çokkiracılı takip ve muhasebe uygulaması.
+
+## Kurulum
+1. PHP 8.1+ ve pdo_mysql, mbstring, intl, curl, json, zip, gd, fileinfo eklentilerinin aktif olduğundan emin olun.
+2. MySQL'de bir veritabanı ve kullanıcı oluşturup yetkilerini verin.
+3. phpMyAdmin'de hedef veritabanını seçin ve `app/sql/schema.sql` ardından `app/sql/seed.sql` dosyalarını içe aktarın.
+4. `app/config/.env` dosyasını oluşturup `.env.example` içeriğine göre düzenleyin.
+5. (Opsiyonel) Cron görevleri için `app/cron/*.php` dosyalarını zamanlayıcıya ekleyin.
+
+## İlk Giriş Bilgileri
+- Yönetici: `admin@example.com` / `Admin123!`
+- Firma: `info@precadmedya.com.tr` / `123456`
+
+Güvenlik sebebiyle ilk girişten sonra parolaları değiştiriniz.

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,31 @@
+<?php
+require __DIR__.'/../app/config/config.php';
+require __DIR__.'/../app/config/auth.php';
+require __DIR__.'/../app/config/rbac.php';
+if(!isYonetici()) { header('Location: /login.php'); exit; }
+$active = $pdo->query("SELECT COUNT(*) FROM firms WHERE status='active'")->fetchColumn();
+$renew = $pdo->query("SELECT COUNT(*) FROM firm_subscriptions WHERE end_date = CURDATE()")->fetchColumn();
+$suspended = $pdo->query("SELECT COUNT(*) FROM firms WHERE status='suspended'")->fetchColumn();
+include __DIR__.'/../partials/header.php';
+?>
+<div class="row g-4">
+  <div class="col-md-4">
+    <div class="card text-center p-3">
+      <h5>Aktif Firmalar</h5>
+      <p class="display-6"><?php echo $active; ?></p>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card text-center p-3">
+      <h5>Bugün Yenilenecek</h5>
+      <p class="display-6"><?php echo $renew; ?></p>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card text-center p-3">
+      <h5>Askıdaki Firmalar</h5>
+      <p class="display-6"><?php echo $suspended; ?></p>
+    </div>
+  </div>
+</div>
+<?php include __DIR__.'/../partials/footer.php'; ?>

--- a/app/config/auth.php
+++ b/app/config/auth.php
@@ -1,0 +1,32 @@
+<?php
+if(session_status() === PHP_SESSION_NONE) session_start();
+function login(PDO $pdo, string $email, string $password) {
+    $stmt = $pdo->prepare("SELECT u.*, f.name AS firm_name FROM users u LEFT JOIN firms f ON u.firm_id=f.id WHERE u.email=? LIMIT 1");
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+    if(!$user || !$user['is_active']) {
+        return 'Geçersiz kullanıcı';
+    }
+    if($user['failed_attempts'] >= 5 && strtotime($user['updated_at']) > time()-900) {
+        return 'Hesap geçici olarak kilitli';
+    }
+    if(!password_verify($password, $user['password_hash'])) {
+        $pdo->prepare("UPDATE users SET failed_attempts = failed_attempts + 1, updated_at=NOW() WHERE id=?")->execute([$user['id']]);
+        return 'Hatalı giriş';
+    }
+    $pdo->prepare("UPDATE users SET failed_attempts=0, last_login_at=NOW(), updated_at=NOW() WHERE id=?")->execute([$user['id']]);
+    session_regenerate_id(true);
+    $_SESSION['user'] = [
+        'id' => $user['id'],
+        'role' => $user['role'],
+        'full_name' => $user['full_name'],
+        'firm_id' => $user['firm_id'],
+        'firm_name' => $user['firm_name']
+    ];
+    return true;
+}
+function logout(): void {
+    if(session_status() === PHP_SESSION_NONE) session_start();
+    $_SESSION = [];
+    session_destroy();
+}

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__.'/env.php';
+if(session_status() === PHP_SESSION_NONE) session_start();
+$timezone = env('TIMEZONE','Europe/Istanbul');
+if(function_exists('date_default_timezone_set')) {
+    date_default_timezone_set($timezone);
+}
+$dsn = 'mysql:host='.env('DB_HOST','localhost').';dbname='.env('DB_NAME','').';charset=utf8mb4';
+$options = [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES => false,
+];
+try {
+    $pdo = new PDO($dsn, env('DB_USER',''), env('DB_PASS',''), $options);
+} catch (PDOException $e) {
+    die('Veritabanına bağlanılamadı.');
+}

--- a/app/config/csrf.php
+++ b/app/config/csrf.php
@@ -1,0 +1,19 @@
+<?php
+if(session_status() === PHP_SESSION_NONE) session_start();
+function csrf_token(): string {
+    if(empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+function csrf_field(): string {
+    return '<input type="hidden" name="csrf_token" value="'.csrf_token().'">';
+}
+function verify_csrf(): void {
+    if($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $token = $_POST['csrf_token'] ?? '';
+        if(!hash_equals($_SESSION['csrf_token'] ?? '', $token)) {
+            die('CSRF doğrulaması başarısız');
+        }
+    }
+}

--- a/app/config/env.php
+++ b/app/config/env.php
@@ -1,0 +1,16 @@
+<?php
+function env(string $key, $default=null) {
+    static $vars = null;
+    if($vars === null) {
+        $path = __DIR__.'/.env';
+        $vars = [];
+        if(file_exists($path)) {
+            foreach(file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+                if(str_starts_with(trim($line),'#') || !str_contains($line,'=')) continue;
+                [$k,$v] = explode('=', $line, 2);
+                $vars[trim($k)] = trim($v);
+            }
+        }
+    }
+    return $vars[$key] ?? $default;
+}

--- a/app/config/rbac.php
+++ b/app/config/rbac.php
@@ -1,0 +1,8 @@
+<?php
+if(session_status() === PHP_SESSION_NONE) session_start();
+function isYonetici(): bool {
+    return ($_SESSION['user']['role'] ?? '') === 'yonetici';
+}
+function isFirma(): bool {
+    return ($_SESSION['user']['role'] ?? '') === 'firma';
+}

--- a/app/config/subscription_guard.php
+++ b/app/config/subscription_guard.php
@@ -1,0 +1,16 @@
+<?php
+function checkSubscription(PDO $pdo, int $firmId): array {
+    $stmt = $pdo->prepare("SELECT *, DATEDIFF(end_date, CURDATE()) as days_left FROM firm_subscriptions WHERE firm_id=? ORDER BY end_date DESC LIMIT 1");
+    $stmt->execute([$firmId]);
+    $sub = $stmt->fetch();
+    if(!$sub) return ['status'=>'missing','days_left'=>0];
+    $today = new DateTime();
+    $end = new DateTime($sub['end_date']);
+    $grace = (clone $end)->modify('+'.$sub['grace_days'].' day');
+    if($today <= $end) {
+        return ['status'=>'active','days_left'=>$sub['days_left']];
+    } elseif($today <= $grace) {
+        return ['status'=>'grace','days_left'=>$today->diff($grace)->days];
+    }
+    return ['status'=>'expired','days_left'=>0];
+}

--- a/app/config/tenant_middleware.php
+++ b/app/config/tenant_middleware.php
@@ -1,0 +1,7 @@
+<?php
+if(session_status() === PHP_SESSION_NONE) session_start();
+function requireFirm(int $firmId): void {
+    if(($_SESSION['user']['role'] ?? '') === 'firma' && $_SESSION['user']['firm_id'] != $firmId) {
+        die('Yetkisiz erişim');
+    }
+}

--- a/app/cron/exchange_rates_cron.php
+++ b/app/cron/exchange_rates_cron.php
@@ -1,0 +1,2 @@
+<?php
+// TODO: Döviz kurlarını güncelleme cron'u

--- a/app/cron/reminder_cron.php
+++ b/app/cron/reminder_cron.php
@@ -1,0 +1,2 @@
+<?php
+// TODO: Hatırlatma e-postaları cron'u

--- a/app/helpers/audit.php
+++ b/app/helpers/audit.php
@@ -1,0 +1,17 @@
+<?php
+if(session_status() === PHP_SESSION_NONE) session_start();
+function audit_log(PDO $pdo, int $firmId, string $entityType, int $entityId, string $action, ?array $old, ?array $new): void {
+    $stmt = $pdo->prepare("INSERT INTO audit_logs (firm_id,user_id,entity_type,entity_id,action,old_values,new_values,ip,user_agent,created_at) VALUES (?,?,?,?,?,?,?,?,?,NOW())");
+    $stmt->execute([
+        $firmId,
+        $_SESSION['user']['id'] ?? null,
+        $entityType,
+        $entityId,
+        $action,
+        $old ? json_encode($old, JSON_UNESCAPED_UNICODE) : null,
+        $new ? json_encode($new, JSON_UNESCAPED_UNICODE) : null,
+        $_SERVER['REMOTE_ADDR'] ?? null,
+        $_SERVER['HTTP_USER_AGENT'] ?? null
+    ]);
+}
+?>

--- a/app/helpers/csv.php
+++ b/app/helpers/csv.php
@@ -1,0 +1,36 @@
+<?php
+function read_csv(string $file): array {
+    $rows = [];
+    if(($handle = fopen($file, 'r')) !== false) {
+        $headers = fgetcsv($handle, 0, ',');
+        if(!$headers) { fclose($handle); return $rows; }
+        if(isset($headers[0]) && str_starts_with($headers[0], "\xEF\xBB\xBF")) {
+            $headers[0] = substr($headers[0], 3);
+        }
+        while(($data = fgetcsv($handle, 0, ',')) !== false) {
+            if(count($data) == 1 && $data[0] === null) continue;
+            $row = [];
+            foreach($headers as $i => $h) {
+                $row[$h] = $data[$i] ?? null;
+            }
+            $rows[] = $row;
+        }
+        fclose($handle);
+    }
+    return $rows;
+}
+function output_csv(array $headers, array $rows, string $filename): void {
+    header('Content-Type: text/csv; charset=utf-8');
+    header('Content-Disposition: attachment; filename="'.$filename.'"');
+    echo "\xEF\xBB\xBF"; // BOM
+    $out = fopen('php://output', 'w');
+    fputcsv($out, $headers);
+    foreach($rows as $row) {
+        $line = [];
+        foreach($headers as $h) { $line[] = $row[$h] ?? ''; }
+        fputcsv($out, $line);
+    }
+    fclose($out);
+    exit;
+}
+?>

--- a/app/helpers/pagination.php
+++ b/app/helpers/pagination.php
@@ -1,0 +1,20 @@
+<?php
+function paginate(int $total, int $page, int $perPage): array {
+    $pages = max(1, (int)ceil($total / $perPage));
+    $page = max(1, min($page, $pages));
+    $offset = ($page - 1) * $perPage;
+    return ['total'=>$total,'pages'=>$pages,'page'=>$page,'per_page'=>$perPage,'offset'=>$offset];
+}
+function pagination_links(array $pagination, array $query): string {
+    if($pagination['pages'] <= 1) return '';
+    $html = '<nav><ul class="pagination">';
+    for($i=1;$i<=$pagination['pages'];$i++) {
+        $query['page'] = $i;
+        $url = '?' . http_build_query($query);
+        $active = $i == $pagination['page'] ? ' active' : '';
+        $html .= '<li class="page-item'.$active.'"><a class="page-link" href="'.$url.'">'.$i.'</a></li>';
+    }
+    $html .= '</ul></nav>';
+    return $html;
+}
+?>

--- a/app/lib/logger.php
+++ b/app/lib/logger.php
@@ -1,0 +1,11 @@
+<?php
+class Logger {
+    protected string $file;
+    public function __construct(string $file) {
+        $this->file = $file;
+    }
+    public function info(string $message): void {
+        $date = date('Y-m-d H:i:s');
+        file_put_contents($this->file, "[$date] $message\n", FILE_APPEND);
+    }
+}

--- a/app/sql/schema.sql
+++ b/app/sql/schema.sql
@@ -1,0 +1,120 @@
+-- Schema without CREATE DATABASE/USE
+SET NAMES utf8mb4;
+SET time_zone = '+00:00';
+
+CREATE TABLE firms (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  slug VARCHAR(255) NOT NULL UNIQUE,
+  email VARCHAR(255) NOT NULL,
+  phone VARCHAR(50) DEFAULT NULL,
+  address VARCHAR(255) DEFAULT NULL,
+  status ENUM('active','suspended','cancelled') DEFAULT 'active',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE users (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NULL,
+  role ENUM('yonetici','firma') DEFAULT 'firma',
+  full_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  is_active TINYINT(1) DEFAULT 1,
+  failed_attempts TINYINT UNSIGNED DEFAULT 0,
+  last_login_at DATETIME NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_users_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE settings (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NOT NULL UNIQUE,
+  brand_name VARCHAR(255) DEFAULT NULL,
+  logo_path VARCHAR(255) DEFAULT NULL,
+  theme_primary_color VARCHAR(7) DEFAULT '#1d4ed8',
+  currency_method ENUM('transaction_date','latest') DEFAULT 'latest',
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_settings_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE services (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  service_name VARCHAR(255) NOT NULL UNIQUE,
+  description TEXT,
+  price DECIMAL(12,2) DEFAULT 0.00,
+  period ENUM('ay','yil') NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO services (service_name, description, price, period, created_at)
+VALUES ('Temel Hizmet','Varsayılan servis',0.00,'ay',NOW())
+ON DUPLICATE KEY UPDATE description=VALUES(description), price=VALUES(price), period=VALUES(period);
+
+CREATE TABLE firm_subscriptions (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NOT NULL,
+  service_id INT UNSIGNED NOT NULL,
+  plan ENUM('monthly','yearly') NOT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  status ENUM('active','expired','suspended') DEFAULT 'active',
+  auto_renew TINYINT(1) DEFAULT 0,
+  grace_days INT UNSIGNED DEFAULT 7,
+  last_payment_at DATETIME NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_firm_end (firm_id, end_date),
+  CONSTRAINT fk_subscription_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE CASCADE,
+  CONSTRAINT fk_subscription_service FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE audit_logs (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NULL,
+  user_id INT UNSIGNED NULL,
+  entity_type VARCHAR(64) NOT NULL,
+  entity_id BIGINT UNSIGNED NULL,
+  action ENUM('create','update','delete','login','logout') NOT NULL,
+  old_values JSON NULL,
+  new_values JSON NULL,
+  ip VARCHAR(45) NULL,
+  user_agent VARCHAR(255) NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_audit_firm (firm_id),
+  CONSTRAINT fk_audit_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE SET NULL,
+  CONSTRAINT fk_audit_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE customers (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NOT NULL,
+  full_name VARCHAR(120) NOT NULL,
+  email VARCHAR(150) NULL,
+  phone VARCHAR(50) NULL,
+  company VARCHAR(150) NULL,
+  tax_no VARCHAR(50) NULL,
+  address TEXT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_cust_firm (firm_id),
+  CONSTRAINT fk_cust_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE products (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  firm_id INT UNSIGNED NOT NULL,
+  name VARCHAR(150) NOT NULL,
+  sku VARCHAR(80) NOT NULL,
+  default_currency ENUM('TRY','USD','EUR','GBP') NOT NULL DEFAULT 'TRY',
+  base_price DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+  vat_rate DECIMAL(5,2) NOT NULL DEFAULT 20.00,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_product_sku_per_firm (firm_id, sku),
+  INDEX idx_prod_firm (firm_id),
+  CONSTRAINT fk_prod_firm FOREIGN KEY (firm_id) REFERENCES firms(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/app/sql/seed.sql
+++ b/app/sql/seed.sql
@@ -1,0 +1,17 @@
+INSERT INTO firms (name, slug, email, status, created_at, updated_at)
+VALUES ('Precad Medya','precad-medya','info@precadmedya.com.tr','active',NOW(),NOW());
+
+INSERT INTO settings (firm_id, brand_name, logo_path, theme_primary_color, currency_method, created_at, updated_at)
+VALUES (1,'Precad Medya',NULL,'#1d4ed8','latest',NOW(),NOW());
+
+INSERT INTO users (firm_id, role, full_name, email, password_hash, created_at, updated_at)
+VALUES
+(NULL,'yonetici','Sistem Yöneticisi','admin@example.com','$2y$12$e.91VviNoIn0DiWXboSNPuAQkkT.17tiNM9AhHWCVX8ENtxosREEC',NOW(),NOW()),
+(1,'firma','Precad Medya','info@precadmedya.com.tr','$2y$12$EF5FbbpY3cuTUkgLTwOT0.XzWl8OSQAKUZTu1qkay2ZLJgzVXXhyS',NOW(),NOW());
+
+INSERT INTO services (service_name, description, price, period, created_at)
+VALUES ('Temel Hizmet','Varsayılan servis',0.00,'ay',NOW())
+ON DUPLICATE KEY UPDATE description=VALUES(description), price=VALUES(price), period=VALUES(period);
+
+INSERT INTO firm_subscriptions (firm_id, service_id, plan, start_date, end_date, status, auto_renew, grace_days, created_at)
+VALUES (1,1,'monthly',CURDATE(),DATE_ADD(CURDATE(), INTERVAL 30 DAY),'active',1,7,NOW());

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,0 +1,21 @@
+body {
+  background-color: #f8f9fa;
+  color: #212529;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+}
+
+.navbar-brand img {
+  height: 40px;
+}
+
+.card {
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+  border-radius: 0.5rem;
+}
+
+.table thead {
+  background-color: #1d4ed8;
+  color: #fff;
+}
+
+/*# sourceMappingURL=theme.css.map */

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,4 @@
+document.addEventListener('DOMContentLoaded', function(){
+  var toastElList = [].slice.call(document.querySelectorAll('.toast'));
+  toastElList.map(function(toastEl){ return new bootstrap.Toast(toastEl); }).forEach(t=>t.show());
+});

--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -1,0 +1,9 @@
+@import 'variables';
+body {
+  background-color: $body-bg;
+  color: $body-color;
+  font-family: $font-family-base;
+}
+.navbar-brand img { height: 40px; }
+.card { box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,.075); border-radius: .5rem; }
+.table thead { background-color: $primary; color: #fff; }

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -1,0 +1,4 @@
+$primary: #1d4ed8;
+$font-family-base: 'Helvetica Neue', Arial, sans-serif;
+$body-bg: #f8f9fa;
+$body-color: #212529;

--- a/assets/uploads/.htaccess
+++ b/assets/uploads/.htaccess
@@ -1,0 +1,2 @@
+php_flag engine off
+Options -ExecCGI

--- a/customer.php
+++ b/customer.php
@@ -1,0 +1,32 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+require __DIR__.'/app/config/auth.php';
+require __DIR__.'/app/config/rbac.php';
+require __DIR__.'/app/config/tenant_middleware.php';
+require __DIR__.'/app/config/subscription_guard.php';
+
+if(!isset($_SESSION['user'])) { header('Location: /login.php'); exit; }
+$id = (int)($_GET['id'] ?? 0);
+$stmt = $pdo->prepare("SELECT * FROM customers WHERE id=?");
+$stmt->execute([$id]);
+$customer = $stmt->fetch();
+if(!$customer) { die('Müşteri bulunamadı'); }
+requireFirm((int)$customer['firm_id']);
+$firmId = $customer['firm_id'];
+$sub = checkSubscription($pdo,$firmId);
+if($sub['status']==='expired') { die('Aboneliğiniz sona ermiş.'); }
+include __DIR__.'/partials/header.php';
+if($sub['status']==='grace') echo '<div class="alert alert-warning sticky-top">Aboneliğiniz yenilenmek üzere; kritik işlemler devre dışıdır.</div>';
+?>
+<h3 class="mb-3">Müşteri Detayı</h3>
+<div class="card p-3">
+    <p><strong>Ad Soyad:</strong> <?php echo htmlspecialchars($customer['full_name']); ?></p>
+    <p><strong>E-posta:</strong> <?php echo htmlspecialchars($customer['email']); ?></p>
+    <p><strong>Telefon:</strong> <?php echo htmlspecialchars($customer['phone']); ?></p>
+    <p><strong>Firma:</strong> <?php echo htmlspecialchars($customer['company']); ?></p>
+    <p><strong>Vergi No:</strong> <?php echo htmlspecialchars($customer['tax_no']); ?></p>
+    <p><strong>Adres:</strong> <?php echo nl2br(htmlspecialchars($customer['address'])); ?></p>
+</div>
+<a href="customers.php" class="btn btn-secondary mt-3">Geri</a>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/customer_add.php
+++ b/customer_add.php
@@ -1,0 +1,70 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+require __DIR__.'/app/config/auth.php';
+require __DIR__.'/app/config/rbac.php';
+require __DIR__.'/app/config/tenant_middleware.php';
+require __DIR__.'/app/config/subscription_guard.php';
+require __DIR__.'/app/helpers/audit.php';
+
+if(!isset($_SESSION['user'])) { header('Location: /login.php'); exit; }
+$isAdmin = isYonetici();
+if($isAdmin) {
+    $firms = $pdo->query("SELECT id,name FROM firms WHERE status='active' ORDER BY name")->fetchAll();
+    $firmId = (int)($_GET['firm_id'] ?? ($firms[0]['id'] ?? 0));
+    $validIds = array_column($firms,'id');
+    if(!in_array($firmId,$validIds)) { $firmId = $firms ? $firms[0]['id'] : 0; }
+} else {
+    $firms = [];
+    $firmId = $_SESSION['user']['firm_id'];
+}
+requireFirm($firmId);
+$sub = checkSubscription($pdo,$firmId);
+if($sub['status']!=='active') { $_SESSION['flash']['danger']='Bu işlem için aboneliğiniz uygun değil.'; header('Location: customers.php'.($isAdmin?'?firm_id='.$firmId:'')); exit; }
+
+if($_SERVER['REQUEST_METHOD']==='POST') {
+    verify_csrf();
+    $full = trim($_POST['full_name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $phone = trim($_POST['phone'] ?? '');
+    $company = trim($_POST['company'] ?? '');
+    $tax = trim($_POST['tax_no'] ?? '');
+    $addr = trim($_POST['address'] ?? '');
+    if($full==='') {
+        $_SESSION['flash']['danger'] = 'Ad Soyad gerekli';
+    } else {
+        $stmt = $pdo->prepare("INSERT INTO customers (firm_id,full_name,email,phone,company,tax_no,address) VALUES (?,?,?,?,?,?,?)");
+        $stmt->execute([$firmId,$full,$email?:null,$phone?:null,$company?:null,$tax?:null,$addr?:null]);
+        $cid = (int)$pdo->lastInsertId();
+        audit_log($pdo,$firmId,'customer',$cid,'create',null,[
+            'full_name'=>$full,'email'=>$email,'phone'=>$phone,'company'=>$company,'tax_no'=>$tax,'address'=>$addr]);
+        $_SESSION['flash']['success']='Müşteri eklendi';
+        header('Location: customers.php'.($isAdmin?'?firm_id='.$firmId:''));
+        exit;
+    }
+}
+include __DIR__.'/partials/header.php';
+?>
+<h3 class="mb-3">Müşteri Ekle</h3>
+<form method="post">
+    <?php echo csrf_field(); ?>
+    <?php if($isAdmin): ?>
+    <div class="mb-3">
+        <label class="form-label">Firma</label>
+        <select name="firm_id" class="form-select">
+            <?php foreach($firms as $f): ?>
+            <option value="<?php echo $f['id']; ?>" <?php if($f['id']==$firmId) echo 'selected'; ?>><?php echo htmlspecialchars($f['name']); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <?php endif; ?>
+    <div class="mb-3"><label class="form-label">Ad Soyad</label><input type="text" name="full_name" class="form-control" required></div>
+    <div class="mb-3"><label class="form-label">E-posta</label><input type="email" name="email" class="form-control"></div>
+    <div class="mb-3"><label class="form-label">Telefon</label><input type="text" name="phone" class="form-control"></div>
+    <div class="mb-3"><label class="form-label">Firma</label><input type="text" name="company" class="form-control"></div>
+    <div class="mb-3"><label class="form-label">Vergi No</label><input type="text" name="tax_no" class="form-control"></div>
+    <div class="mb-3"><label class="form-label">Adres</label><textarea name="address" class="form-control"></textarea></div>
+    <button class="btn btn-primary">Kaydet</button>
+    <a href="customers.php<?php echo $isAdmin?'?firm_id='.$firmId:''; ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/customer_delete.php
+++ b/customer_delete.php
@@ -1,0 +1,27 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+require __DIR__.'/app/config/auth.php';
+require __DIR__.'/app/config/rbac.php';
+require __DIR__.'/app/config/tenant_middleware.php';
+require __DIR__.'/app/config/subscription_guard.php';
+require __DIR__.'/app/helpers/audit.php';
+
+if($_SERVER['REQUEST_METHOD'] !== 'POST') { header('Location: customers.php'); exit; }
+if(!isset($_SESSION['user'])) { header('Location: /login.php'); exit; }
+verify_csrf();
+$id = (int)($_POST['id'] ?? 0);
+$stmt = $pdo->prepare("SELECT * FROM customers WHERE id=?");
+$stmt->execute([$id]);
+$customer = $stmt->fetch();
+if(!$customer) { header('Location: customers.php'); exit; }
+requireFirm((int)$customer['firm_id']);
+$firmId = (int)$customer['firm_id'];
+$sub = checkSubscription($pdo,$firmId);
+if($sub['status']!=='active') { $_SESSION['flash']['danger']='Bu işlem için aboneliğiniz uygun değil.'; header('Location: customers.php'); exit; }
+$pdo->prepare("DELETE FROM customers WHERE id=?")->execute([$id]);
+audit_log($pdo,$firmId,'customer',$id,'delete',$customer,null);
+$_SESSION['flash']['success']='Müşteri silindi';
+$isAdmin = isYonetici();
+header('Location: customers.php'.($isAdmin?'?firm_id='.$firmId:''));
+exit;

--- a/customer_edit.php
+++ b/customer_edit.php
@@ -1,0 +1,57 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+require __DIR__.'/app/config/auth.php';
+require __DIR__.'/app/config/rbac.php';
+require __DIR__.'/app/config/tenant_middleware.php';
+require __DIR__.'/app/config/subscription_guard.php';
+require __DIR__.'/app/helpers/audit.php';
+
+if(!isset($_SESSION['user'])) { header('Location: /login.php'); exit; }
+$id = (int)($_GET['id'] ?? 0);
+$stmt = $pdo->prepare("SELECT * FROM customers WHERE id=?");
+$stmt->execute([$id]);
+$customer = $stmt->fetch();
+if(!$customer) { die('Müşteri bulunamadı'); }
+requireFirm((int)$customer['firm_id']);
+$isAdmin = isYonetici();
+$firmId = $customer['firm_id'];
+$sub = checkSubscription($pdo,$firmId);
+if($sub['status']!=='active') { $_SESSION['flash']['danger']='Bu işlem için aboneliğiniz uygun değil.'; header('Location: customers.php'.($isAdmin?'?firm_id='.$firmId:'')); exit; }
+
+if($_SERVER['REQUEST_METHOD']==='POST') {
+    verify_csrf();
+    $full = trim($_POST['full_name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $phone = trim($_POST['phone'] ?? '');
+    $company = trim($_POST['company'] ?? '');
+    $tax = trim($_POST['tax_no'] ?? '');
+    $addr = trim($_POST['address'] ?? '');
+    if($full==='') {
+        $_SESSION['flash']['danger'] = 'Ad Soyad gerekli';
+    } else {
+        $old = $customer;
+        $stmt = $pdo->prepare("UPDATE customers SET full_name=?, email=?, phone=?, company=?, tax_no=?, address=? WHERE id=?");
+        $stmt->execute([$full,$email?:null,$phone?:null,$company?:null,$tax?:null,$addr?:null,$id]);
+        audit_log($pdo,$firmId,'customer',$id,'update',$old,[
+            'full_name'=>$full,'email'=>$email,'phone'=>$phone,'company'=>$company,'tax_no'=>$tax,'address'=>$addr]);
+        $_SESSION['flash']['success']='Müşteri güncellendi';
+        header('Location: customers.php'.($isAdmin?'?firm_id='.$firmId:''));
+        exit;
+    }
+}
+include __DIR__.'/partials/header.php';
+?>
+<h3 class="mb-3">Müşteri Düzenle</h3>
+<form method="post">
+    <?php echo csrf_field(); ?>
+    <div class="mb-3"><label class="form-label">Ad Soyad</label><input type="text" name="full_name" class="form-control" value="<?php echo htmlspecialchars($customer['full_name']); ?>" required></div>
+    <div class="mb-3"><label class="form-label">E-posta</label><input type="email" name="email" class="form-control" value="<?php echo htmlspecialchars($customer['email']); ?>"></div>
+    <div class="mb-3"><label class="form-label">Telefon</label><input type="text" name="phone" class="form-control" value="<?php echo htmlspecialchars($customer['phone']); ?>"></div>
+    <div class="mb-3"><label class="form-label">Firma</label><input type="text" name="company" class="form-control" value="<?php echo htmlspecialchars($customer['company']); ?>"></div>
+    <div class="mb-3"><label class="form-label">Vergi No</label><input type="text" name="tax_no" class="form-control" value="<?php echo htmlspecialchars($customer['tax_no']); ?>"></div>
+    <div class="mb-3"><label class="form-label">Adres</label><textarea name="address" class="form-control"><?php echo htmlspecialchars($customer['address']); ?></textarea></div>
+    <button class="btn btn-primary">Kaydet</button>
+    <a href="customers.php<?php echo $isAdmin?'?firm_id='.$firmId:''; ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/customers.php
+++ b/customers.php
@@ -1,0 +1,183 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+require __DIR__.'/app/config/auth.php';
+require __DIR__.'/app/config/rbac.php';
+require __DIR__.'/app/config/tenant_middleware.php';
+require __DIR__.'/app/config/subscription_guard.php';
+require __DIR__.'/app/helpers/pagination.php';
+require __DIR__.'/app/helpers/csv.php';
+require __DIR__.'/app/helpers/audit.php';
+
+if(!isset($_SESSION['user'])) { header('Location: /login.php'); exit; }
+$isAdmin = isYonetici();
+// firm selection
+if($isAdmin) {
+    $firms = $pdo->query("SELECT id,name FROM firms WHERE status='active' ORDER BY name")->fetchAll();
+    $firmId = (int)($_GET['firm_id'] ?? ($firms[0]['id'] ?? 0));
+    $validIds = array_column($firms,'id');
+    if(!in_array($firmId,$validIds)) { $firmId = $firms ? $firms[0]['id'] : 0; }
+} else {
+    $firms = [];
+    $firmId = $_SESSION['user']['firm_id'];
+}
+requireFirm($firmId);
+$sub = checkSubscription($pdo,$firmId);
+if($sub['status']==='expired') { die('Aboneliğiniz sona ermiş.'); }
+
+// handle CSV export
+$search = trim($_GET['search'] ?? '');
+$perPage = (int)($_GET['per_page'] ?? 10); if(!in_array($perPage,[10,25,50])) $perPage=10;
+$page = max(1,(int)($_GET['page'] ?? 1));
+$allowedSort = ['full_name','email','phone','company','created_at'];
+$sort = $_GET['sort'] ?? 'full_name'; if(!in_array($sort,$allowedSort)) $sort='full_name';
+$dir = strtolower($_GET['dir'] ?? 'asc')==='desc'?'DESC':'ASC';
+
+$where = "WHERE firm_id=:firm_id";
+$params = ['firm_id'=>$firmId];
+if($search!=='') {
+    $where .= " AND (full_name LIKE :q OR email LIKE :q OR company LIKE :q)";
+    $params['q'] = "%$search%";
+}
+
+if(isset($_GET['export']) && $_GET['export']=='1') {
+    $stmt = $pdo->prepare("SELECT id,full_name,email,phone,company,tax_no,address,created_at FROM customers $where ORDER BY $sort $dir");
+    $stmt->execute($params);
+    $rows = $stmt->fetchAll();
+    output_csv(['id','full_name','email','phone','company','tax_no','address','created_at'],$rows,'customers.csv');
+}
+
+// CSV import
+if($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_csv'])) {
+    verify_csrf();
+    $messages=[]; $success=0; $error=0;
+    if($sub['status']==='grace') {
+        $messages[]='Grace döneminde içe aktarma devre dışı.'; $error++;
+    } else {
+        $file = $_FILES['csv'] ?? null;
+        if($file && $file['error']===UPLOAD_ERR_OK && $file['size'] <= 2*1024*1024) {
+            $rows = read_csv($file['tmp_name']);
+            foreach($rows as $i=>$row) {
+                $line = $i+2; // header offset
+                $full = trim($row['full_name'] ?? '');
+                if($full==='') { $messages[]="Satır $line: isim eksik"; $error++; continue; }
+                $email = trim($row['email'] ?? '');
+                $phone = $row['phone'] ?? null;
+                $company = $row['company'] ?? null;
+                $tax = $row['tax_no'] ?? null;
+                $addr = $row['address'] ?? null;
+                if($email!=='') {
+                    $stmt = $pdo->prepare("SELECT * FROM customers WHERE firm_id=? AND email=? LIMIT 1");
+                    $stmt->execute([$firmId,$email]);
+                    if($existing = $stmt->fetch()) {
+                        $pdo->prepare("UPDATE customers SET full_name=?, phone=?, company=?, tax_no=?, address=? WHERE id=?")
+                            ->execute([$full,$phone,$company,$tax,$addr,$existing['id']]);
+                        audit_log($pdo,$firmId,'customer',(int)$existing['id'],'update',$existing,[
+                            'full_name'=>$full,'email'=>$email,'phone'=>$phone,'company'=>$company,'tax_no'=>$tax,'address'=>$addr]);
+                        $messages[]="Satır $line: güncellendi"; $success++;
+                        continue;
+                    }
+                }
+                $pdo->prepare("INSERT INTO customers (firm_id,full_name,email,phone,company,tax_no,address) VALUES (?,?,?,?,?,?,?)")
+                    ->execute([$firmId,$full,$email?:null,$phone,$company,$tax,$addr]);
+                $cid = (int)$pdo->lastInsertId();
+                audit_log($pdo,$firmId,'customer',$cid,'create',null,[
+                    'full_name'=>$full,'email'=>$email,'phone'=>$phone,'company'=>$company,'tax_no'=>$tax,'address'=>$addr]);
+                $messages[]="Satır $line: eklendi"; $success++;
+            }
+        } else {
+            $messages[]='Geçerli bir CSV dosyası seçin'; $error++;
+        }
+    }
+    $_SESSION['import_messages']=$messages;
+    header('Location: '.($_SERVER['PHP_SELF']).($isAdmin?'?firm_id='.$firmId:''));
+    exit;
+}
+
+$countStmt = $pdo->prepare("SELECT COUNT(*) FROM customers $where");
+$countStmt->execute($params);
+$total = (int)$countStmt->fetchColumn();
+$pagination = paginate($total,$page,$perPage);
+$listStmt = $pdo->prepare("SELECT * FROM customers $where ORDER BY $sort $dir LIMIT :offset,:pp");
+foreach($params as $k=>$v) $listStmt->bindValue(':'.$k,$v);
+$listStmt->bindValue(':offset',$pagination['offset'],PDO::PARAM_INT);
+$listStmt->bindValue(':pp',$pagination['per_page'],PDO::PARAM_INT);
+$listStmt->execute();
+$customers = $listStmt->fetchAll();
+
+$queryBase = ['firm_id'=>$firmId,'search'=>$search,'sort'=>$sort,'dir'=>strtolower($dir),'per_page'=>$perPage];
+include __DIR__.'/partials/header.php';
+if($sub['status']==='grace') echo '<div class="alert alert-warning sticky-top">Aboneliğiniz yenilenmek üzere; kritik işlemler devre dışıdır.</div>';
+if(isset($_SESSION['import_messages'])) {
+    echo '<div class="alert alert-info"><ul class="mb-0">';
+    foreach($_SESSION['import_messages'] as $m) echo '<li>'.htmlspecialchars($m).'</li>';
+    echo '</ul></div>'; unset($_SESSION['import_messages']);
+}
+?>
+<div class="d-flex justify-content-between mb-3">
+    <form class="d-flex" method="get">
+        <?php if($isAdmin): ?>
+            <select name="firm_id" class="form-select me-2" onchange="this.form.submit()">
+                <?php foreach($firms as $f): ?>
+                    <option value="<?php echo $f['id']; ?>" <?php if($f['id']==$firmId) echo 'selected'; ?>><?php echo htmlspecialchars($f['name']); ?></option>
+                <?php endforeach; ?>
+            </select>
+        <?php endif; ?>
+        <input type="search" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control me-2" placeholder="Ara">
+        <select name="per_page" class="form-select me-2" onchange="this.form.submit()">
+            <?php foreach([10,25,50] as $n): ?>
+                <option value="<?php echo $n; ?>" <?php if($n==$perPage) echo 'selected'; ?>><?php echo $n; ?></option>
+            <?php endforeach; ?>
+        </select>
+        <button class="btn btn-outline-secondary" type="submit">Filtrele</button>
+    </form>
+    <div>
+        <a href="?<?php echo http_build_query(array_merge($queryBase,['export'=>1])); ?>" class="btn btn-success me-2">Dışa aktar (CSV)</a>
+        <button class="btn btn-primary" <?php if($sub['status']==='grace') echo 'disabled'; ?> onclick="location.href='customer_add.php<?php echo $isAdmin?'?firm_id='.$firmId:''; ?>'">Müşteri Ekle</button>
+    </div>
+</div>
+<form method="post" enctype="multipart/form-data" class="mb-3">
+    <?php echo csrf_field(); ?>
+    <div class="input-group">
+        <input type="file" name="csv" accept="text/csv" class="form-control" <?php if($sub['status']==='grace') echo 'disabled'; ?>>
+        <button class="btn btn-outline-secondary" name="import_csv" <?php if($sub['status']==='grace') echo 'disabled'; ?>>İçe aktar (CSV)</button>
+    </div>
+</form>
+<div class="table-responsive">
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'full_name','dir'=>$sort=='full_name' && $dir=='ASC'?'desc':'asc'])); ?>">Ad Soyad</a></th>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'email','dir'=>$sort=='email' && $dir=='ASC'?'desc':'asc'])); ?>">E-posta</a></th>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'phone','dir'=>$sort=='phone' && $dir=='ASC'?'desc':'asc'])); ?>">Telefon</a></th>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'company','dir'=>$sort=='company' && $dir=='ASC'?'desc':'asc'])); ?>">Firma</a></th>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'created_at','dir'=>$sort=='created_at' && $dir=='ASC'?'desc':'asc'])); ?>">Kayıt</a></th>
+            <th>İşlemler</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if(!$customers): ?>
+        <tr><td colspan="6" class="text-center">Kayıt bulunamadı.</td></tr>
+    <?php else: foreach($customers as $c): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($c['full_name']); ?></td>
+            <td><?php echo htmlspecialchars($c['email']); ?></td>
+            <td><?php echo htmlspecialchars($c['phone']); ?></td>
+            <td><?php echo htmlspecialchars($c['company']); ?></td>
+            <td><?php echo htmlspecialchars($c['created_at']); ?></td>
+            <td>
+                <a class="btn btn-sm btn-info" href="customer.php?id=<?php echo $c['id']; ?>">Görüntüle</a>
+                <a class="btn btn-sm btn-secondary" <?php if($sub['status']==='grace') echo 'disabled'; ?> href="customer_edit.php?id=<?php echo $c['id']; ?>">Düzenle</a>
+                <form method="post" action="customer_delete.php" class="d-inline" onsubmit="return confirm('Silinsin mi?');">
+                    <?php echo csrf_field(); ?>
+                    <input type="hidden" name="id" value="<?php echo $c['id']; ?>">
+                    <button class="btn btn-sm btn-danger" <?php if($sub['status']==='grace') echo 'disabled'; ?>>Sil</button>
+                </form>
+            </td>
+        </tr>
+    <?php endforeach; endif; ?>
+    </tbody>
+</table>
+</div>
+<?php echo pagination_links($pagination,$queryBase); ?>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+if(!isset($_SESSION['user_id'])) {
+    header('Location: /login.php');
+    exit;
+}
+include __DIR__.'/partials/header.php';
+?>
+<h1 class="mb-4">Hoş geldiniz, <?php echo htmlspecialchars($_SESSION['name']); ?>!</h1>
+<p>Rolünüz: <?php echo htmlspecialchars($_SESSION['role']); ?></p>
+<?php if($_SESSION['role'] === 'admin'): ?>
+    <a href="#" class="btn btn-primary">Servisleri Yönet</a>
+<?php else: ?>
+    <h5>Abonelikleriniz</h5>
+    <div class="alert alert-info">Henüz abonelik bulunmuyor.</div>
+<?php endif; ?>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/firma/dashboard.php
+++ b/firma/dashboard.php
@@ -1,0 +1,20 @@
+<?php
+require __DIR__.'/../app/config/config.php';
+require __DIR__.'/../app/config/auth.php';
+require __DIR__.'/../app/config/rbac.php';
+require __DIR__.'/../app/config/subscription_guard.php';
+if(!isFirma()) { header('Location: /login.php'); exit; }
+$sub = checkSubscription($pdo, $_SESSION['user']['firm_id']);
+include __DIR__.'/../partials/header.php';
+if($sub['status'] !== 'expired' && $sub['days_left'] <= 7) {
+    echo '<div class="alert alert-warning">Aboneliğiniz bitmek üzere...</div>';
+}
+?>
+<div class="mb-3">
+  <span class="badge bg-success">Kalan: <?php echo $sub['days_left']; ?> gün</span>
+</div>
+<div class="card p-4">
+  <h5>Yaklaşan Hizmetler</h5>
+  <p>Henüz bir veri yok.</p>
+</div>
+<?php include __DIR__.'/../partials/footer.php'; ?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+if(isset($_SESSION['user_id'])) {
+    header('Location: /dashboard.php');
+    exit;
+}
+include __DIR__.'/partials/header.php';
+?>
+<div class="text-center py-5">
+    <h1 class="mb-4">Takip / Muhasebe Sistemi</h1>
+    <p class="mb-4">Hoş geldiniz. Lütfen giriş yapın veya kayıt olun.</p>
+    <a class="btn btn-primary me-2" href="/login.php">Giriş</a>
+    <a class="btn btn-secondary" href="/register.php">Kayıt Ol</a>
+</div>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,53 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+session_start();
+if(isset($_SESSION['user_id'])) {
+    header('Location: /dashboard.php');
+    exit;
+}
+if($_SERVER['REQUEST_METHOD'] === 'POST') {
+    verify_csrf();
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $stmt = $pdo->prepare("SELECT u.id, u.full_name, u.password_hash, u.role, u.firm_id, f.name AS firm_name FROM users u LEFT JOIN firms f ON u.firm_id=f.id WHERE u.email = ? LIMIT 1");
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+    if($user && password_verify($password, $user['password_hash'])) {
+        session_regenerate_id(true);
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['role'] = $user['role'] === 'yonetici' ? 'admin' : 'firma';
+        $_SESSION['name'] = $user['full_name'];
+        $_SESSION['user'] = [
+            'id' => $user['id'],
+            'role' => $user['role'],
+            'full_name' => $user['full_name'],
+            'firm_id' => $user['firm_id'],
+            'firm_name' => $user['firm_name']
+        ];
+        header('Location: /dashboard.php');
+        exit;
+    } else {
+        $_SESSION['flash']['danger'] = 'Geçersiz e-posta veya parola';
+    }
+}
+include __DIR__.'/partials/header.php';
+?>
+<div class="row justify-content-center">
+    <div class="col-md-4">
+        <form method="post" class="card p-4">
+            <h3 class="mb-3">Giriş Yap</h3>
+            <?php echo csrf_field(); ?>
+            <div class="mb-3">
+                <label class="form-label">E-posta</label>
+                <input type="email" name="email" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Parola</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-primary w-100">Giriş</button>
+        </form>
+    </div>
+</div>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+$_SESSION = [];
+session_destroy();
+header('Location: /login.php');
+exit;

--- a/partials/alerts.php
+++ b/partials/alerts.php
@@ -1,0 +1,8 @@
+<?php
+if(!empty($_SESSION['flash'])) {
+    foreach($_SESSION['flash'] as $type => $msg) {
+        echo '<div class="alert alert-' . $type . ' alert-dismissible fade show" role="alert">'.htmlspecialchars($msg).'<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>';
+    }
+    unset($_SESSION['flash']);
+}
+?>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,0 +1,6 @@
+<footer class="text-center mt-5 mb-3 text-muted">&copy; <?php echo date('Y'); ?> Takip Muhasebe</footer>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/assets/js/app.js"></script>
+</body>
+</html>

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,0 +1,38 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+?>
+<!doctype html>
+<html lang="tr">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Takip Muhasebe</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/assets/css/theme.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container">
+        <a class="navbar-brand" href="/">Takip Muhasebe</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav ms-auto">
+                <?php if(isset($_SESSION['user_id'])): ?>
+                    <li class="nav-item"><a class="nav-link" href="/dashboard.php">Dashboard</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/customers.php">Müşteriler</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/products.php">Ürünler</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/logout.php">Çıkış</a></li>
+                <?php else: ?>
+                    <li class="nav-item"><a class="nav-link" href="/login.php">Giriş</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/register.php">Kayıt Ol</a></li>
+                <?php endif; ?>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div class="container">
+<?php include __DIR__.'/alerts.php'; ?>

--- a/product_add.php
+++ b/product_add.php
@@ -1,0 +1,81 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+require __DIR__.'/app/config/auth.php';
+require __DIR__.'/app/config/rbac.php';
+require __DIR__.'/app/config/tenant_middleware.php';
+require __DIR__.'/app/config/subscription_guard.php';
+require __DIR__.'/app/helpers/audit.php';
+
+if(!isset($_SESSION['user'])) { header('Location: /login.php'); exit; }
+$isAdmin = isYonetici();
+if($isAdmin) {
+    $firms = $pdo->query("SELECT id,name FROM firms WHERE status='active' ORDER BY name")->fetchAll();
+    $firmId = (int)($_GET['firm_id'] ?? ($firms[0]['id'] ?? 0));
+    $validIds = array_column($firms,'id');
+    if(!in_array($firmId,$validIds)) { $firmId = $firms ? $firms[0]['id'] : 0; }
+} else {
+    $firms=[];
+    $firmId = $_SESSION['user']['firm_id'];
+}
+requireFirm($firmId);
+$sub = checkSubscription($pdo,$firmId);
+if($sub['status']!=='active') { $_SESSION['flash']['danger']='Bu işlem için aboneliğiniz uygun değil.'; header('Location: products.php'.($isAdmin?'?firm_id='.$firmId:'')); exit; }
+
+if($_SERVER['REQUEST_METHOD']==='POST') {
+    verify_csrf();
+    $name = trim($_POST['name'] ?? '');
+    $sku = trim($_POST['sku'] ?? '');
+    $currency = $_POST['default_currency'] ?? 'TRY';
+    $base = (float)($_POST['base_price'] ?? 0);
+    $vat = (float)($_POST['vat_rate'] ?? 0);
+    $active = isset($_POST['is_active']) ? 1 : 0;
+    if($name==='' || $sku==='') {
+        $_SESSION['flash']['danger']='İsim ve SKU gerekli';
+    } else {
+        $stmt = $pdo->prepare("SELECT id FROM products WHERE firm_id=? AND sku=?");
+        $stmt->execute([$firmId,$sku]);
+        if($stmt->fetch()) {
+            $_SESSION['flash']['danger']='SKU zaten mevcut';
+        } else {
+            $pdo->prepare("INSERT INTO products (firm_id,name,sku,default_currency,base_price,vat_rate,is_active) VALUES (?,?,?,?,?,?,?)")
+                ->execute([$firmId,$name,$sku,$currency,$base,$vat,$active]);
+            $pid = (int)$pdo->lastInsertId();
+            audit_log($pdo,$firmId,'product',$pid,'create',null,[
+                'name'=>$name,'sku'=>$sku,'default_currency'=>$currency,'base_price'=>$base,'vat_rate'=>$vat,'is_active'=>$active]);
+            $_SESSION['flash']['success']='Ürün eklendi';
+            header('Location: products.php'.($isAdmin?'?firm_id='.$firmId:''));
+            exit;
+        }
+    }
+}
+include __DIR__.'/partials/header.php';
+?>
+<h3 class="mb-3">Ürün Ekle</h3>
+<form method="post">
+    <?php echo csrf_field(); ?>
+    <?php if($isAdmin): ?>
+    <div class="mb-3">
+        <label class="form-label">Firma</label>
+        <select name="firm_id" class="form-select">
+            <?php foreach($firms as $f): ?><option value="<?php echo $f['id']; ?>" <?php if($f['id']==$firmId) echo 'selected'; ?>><?php echo htmlspecialchars($f['name']); ?></option><?php endforeach; ?>
+        </select>
+    </div>
+    <?php endif; ?>
+    <div class="mb-3"><label class="form-label">Ad</label><input type="text" name="name" class="form-control" required></div>
+    <div class="mb-3"><label class="form-label">SKU</label><input type="text" name="sku" class="form-control" required></div>
+    <div class="mb-3"><label class="form-label">Para Birimi</label>
+        <select name="default_currency" class="form-select">
+            <?php foreach(['TRY','USD','EUR','GBP'] as $c): ?><option value="<?php echo $c; ?>" <?php if($c==='TRY') echo 'selected'; ?>><?php echo $c; ?></option><?php endforeach; ?>
+        </select>
+    </div>
+    <div class="mb-3"><label class="form-label">Baz Fiyat</label><input type="number" step="0.01" name="base_price" class="form-control" value="0"></div>
+    <div class="mb-3"><label class="form-label">KDV%</label><input type="number" step="0.01" name="vat_rate" class="form-control" value="20"></div>
+    <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" name="is_active" id="is_active" checked>
+        <label class="form-check-label" for="is_active">Aktif</label>
+    </div>
+    <button class="btn btn-primary">Kaydet</button>
+    <a href="products.php<?php echo $isAdmin?'?firm_id='.$firmId:''; ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/product_delete.php
+++ b/product_delete.php
@@ -1,0 +1,27 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+require __DIR__.'/app/config/auth.php';
+require __DIR__.'/app/config/rbac.php';
+require __DIR__.'/app/config/tenant_middleware.php';
+require __DIR__.'/app/config/subscription_guard.php';
+require __DIR__.'/app/helpers/audit.php';
+
+if($_SERVER['REQUEST_METHOD'] !== 'POST') { header('Location: products.php'); exit; }
+if(!isset($_SESSION['user'])) { header('Location: /login.php'); exit; }
+verify_csrf();
+$id = (int)($_POST['id'] ?? 0);
+$stmt = $pdo->prepare("SELECT * FROM products WHERE id=?");
+$stmt->execute([$id]);
+$product = $stmt->fetch();
+if(!$product) { header('Location: products.php'); exit; }
+requireFirm((int)$product['firm_id']);
+$firmId = (int)$product['firm_id'];
+$sub = checkSubscription($pdo,$firmId);
+if($sub['status']!=='active') { $_SESSION['flash']['danger']='Bu işlem için aboneliğiniz uygun değil.'; header('Location: products.php'); exit; }
+$pdo->prepare("DELETE FROM products WHERE id=?")->execute([$id]);
+audit_log($pdo,$firmId,'product',$id,'delete',$product,null);
+$_SESSION['flash']['success']='Ürün silindi';
+$isAdmin = isYonetici();
+header('Location: products.php'.($isAdmin?'?firm_id='.$firmId:''));
+exit;

--- a/product_edit.php
+++ b/product_edit.php
@@ -1,0 +1,70 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+require __DIR__.'/app/config/auth.php';
+require __DIR__.'/app/config/rbac.php';
+require __DIR__.'/app/config/tenant_middleware.php';
+require __DIR__.'/app/config/subscription_guard.php';
+require __DIR__.'/app/helpers/audit.php';
+
+if(!isset($_SESSION['user'])) { header('Location: /login.php'); exit; }
+$id = (int)($_GET['id'] ?? 0);
+$stmt = $pdo->prepare("SELECT * FROM products WHERE id=?");
+$stmt->execute([$id]);
+$product = $stmt->fetch();
+if(!$product) { die('Ürün bulunamadı'); }
+requireFirm((int)$product['firm_id']);
+$isAdmin = isYonetici();
+$firmId = $product['firm_id'];
+$sub = checkSubscription($pdo,$firmId);
+if($sub['status']!=='active') { $_SESSION['flash']['danger']='Bu işlem için aboneliğiniz uygun değil.'; header('Location: products.php'.($isAdmin?'?firm_id='.$firmId:'')); exit; }
+
+if($_SERVER['REQUEST_METHOD']==='POST') {
+    verify_csrf();
+    $name = trim($_POST['name'] ?? '');
+    $sku = trim($_POST['sku'] ?? '');
+    $currency = $_POST['default_currency'] ?? 'TRY';
+    $base = (float)($_POST['base_price'] ?? 0);
+    $vat = (float)($_POST['vat_rate'] ?? 0);
+    $active = isset($_POST['is_active']) ? 1 : 0;
+    if($name==='' || $sku==='') {
+        $_SESSION['flash']['danger']='İsim ve SKU gerekli';
+    } else {
+        $stmt = $pdo->prepare("SELECT id FROM products WHERE firm_id=? AND sku=? AND id<>?");
+        $stmt->execute([$firmId,$sku,$id]);
+        if($stmt->fetch()) {
+            $_SESSION['flash']['danger']='SKU zaten mevcut';
+        } else {
+            $old = $product;
+            $pdo->prepare("UPDATE products SET name=?, sku=?, default_currency=?, base_price=?, vat_rate=?, is_active=? WHERE id=?")
+                ->execute([$name,$sku,$currency,$base,$vat,$active,$id]);
+            audit_log($pdo,$firmId,'product',$id,'update',$old,[
+                'name'=>$name,'sku'=>$sku,'default_currency'=>$currency,'base_price'=>$base,'vat_rate'=>$vat,'is_active'=>$active]);
+            $_SESSION['flash']['success']='Ürün güncellendi';
+            header('Location: products.php'.($isAdmin?'?firm_id='.$firmId:''));
+            exit;
+        }
+    }
+}
+include __DIR__.'/partials/header.php';
+?>
+<h3 class="mb-3">Ürün Düzenle</h3>
+<form method="post">
+    <?php echo csrf_field(); ?>
+    <div class="mb-3"><label class="form-label">Ad</label><input type="text" name="name" class="form-control" value="<?php echo htmlspecialchars($product['name']); ?>" required></div>
+    <div class="mb-3"><label class="form-label">SKU</label><input type="text" name="sku" class="form-control" value="<?php echo htmlspecialchars($product['sku']); ?>" required></div>
+    <div class="mb-3"><label class="form-label">Para Birimi</label>
+        <select name="default_currency" class="form-select">
+            <?php foreach(['TRY','USD','EUR','GBP'] as $c): ?><option value="<?php echo $c; ?>" <?php if($c==$product['default_currency']) echo 'selected'; ?>><?php echo $c; ?></option><?php endforeach; ?>
+        </select>
+    </div>
+    <div class="mb-3"><label class="form-label">Baz Fiyat</label><input type="number" step="0.01" name="base_price" class="form-control" value="<?php echo htmlspecialchars($product['base_price']); ?>"></div>
+    <div class="mb-3"><label class="form-label">KDV%</label><input type="number" step="0.01" name="vat_rate" class="form-control" value="<?php echo htmlspecialchars($product['vat_rate']); ?>"></div>
+    <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" name="is_active" id="is_active" <?php if($product['is_active']) echo 'checked'; ?>>
+        <label class="form-check-label" for="is_active">Aktif</label>
+    </div>
+    <button class="btn btn-primary">Kaydet</button>
+    <a href="products.php<?php echo $isAdmin?'?firm_id='.$firmId:''; ?>" class="btn btn-secondary">İptal</a>
+</form>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/products.php
+++ b/products.php
@@ -1,0 +1,179 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+require __DIR__.'/app/config/auth.php';
+require __DIR__.'/app/config/rbac.php';
+require __DIR__.'/app/config/tenant_middleware.php';
+require __DIR__.'/app/config/subscription_guard.php';
+require __DIR__.'/app/helpers/pagination.php';
+require __DIR__.'/app/helpers/csv.php';
+require __DIR__.'/app/helpers/audit.php';
+
+if(!isset($_SESSION['user'])) { header('Location: /login.php'); exit; }
+$isAdmin = isYonetici();
+if($isAdmin) {
+    $firms = $pdo->query("SELECT id,name FROM firms WHERE status='active' ORDER BY name")->fetchAll();
+    $firmId = (int)($_GET['firm_id'] ?? ($firms[0]['id'] ?? 0));
+    $validIds = array_column($firms,'id');
+    if(!in_array($firmId,$validIds)) { $firmId = $firms ? $firms[0]['id'] : 0; }
+} else {
+    $firms = [];
+    $firmId = $_SESSION['user']['firm_id'];
+}
+requireFirm($firmId);
+$sub = checkSubscription($pdo,$firmId);
+if($sub['status']==='expired') { die('Aboneliğiniz sona ermiş.'); }
+
+$search = trim($_GET['search'] ?? '');
+$perPage = (int)($_GET['per_page'] ?? 10); if(!in_array($perPage,[10,25,50])) $perPage=10;
+$page = max(1,(int)($_GET['page'] ?? 1));
+$filterActive = $_GET['active'] ?? 'all';
+$allowedSort = ['name','sku','default_currency','base_price','vat_rate','is_active','created_at'];
+$sort = $_GET['sort'] ?? 'name'; if(!in_array($sort,$allowedSort)) $sort='name';
+$dir = strtolower($_GET['dir'] ?? 'asc')==='desc'?'DESC':'ASC';
+
+$where = "WHERE firm_id=:firm_id";
+$params = ['firm_id'=>$firmId];
+if($search!=='') {
+    $where .= " AND (name LIKE :q OR sku LIKE :q)";
+    $params['q']="%$search%";
+}
+if($filterActive==='1') { $where.=" AND is_active=1"; }
+elseif($filterActive==='0') { $where.=" AND is_active=0"; }
+
+if(isset($_GET['export']) && $_GET['export']=='1') {
+    $stmt = $pdo->prepare("SELECT id,name,sku,default_currency,base_price,vat_rate,is_active,created_at FROM products $where ORDER BY $sort $dir");
+    $stmt->execute($params);
+    $rows = $stmt->fetchAll();
+    output_csv(['id','name','sku','default_currency','base_price','vat_rate','is_active','created_at'],$rows,'products.csv');
+}
+
+if($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['import_csv'])) {
+    verify_csrf();
+    $messages=[]; $success=0; $error=0;
+    if($sub['status']==='grace') {
+        $messages[]='Grace döneminde içe aktarma devre dışı.'; $error++;
+    } else {
+        $file = $_FILES['csv'] ?? null;
+        if($file && $file['error']===UPLOAD_ERR_OK && $file['size']<=2*1024*1024) {
+            $rows = read_csv($file['tmp_name']);
+            $currs = ['TRY','USD','EUR','GBP'];
+            foreach($rows as $i=>$row) {
+                $line=$i+2; $name=trim($row['name']??''); $sku=trim($row['sku']??'');
+                if($name=='' || $sku=='') { $messages[]="Satır $line: isim veya SKU eksik"; $error++; continue; }
+                $currency = strtoupper($row['default_currency'] ?? 'TRY');
+                if(!in_array($currency,$currs)) { $messages[]="Satır $line: geçersiz para birimi"; $error++; continue; }
+                $base = is_numeric($row['base_price'] ?? '') ? $row['base_price'] : 0;
+                $vat = is_numeric($row['vat_rate'] ?? '') ? $row['vat_rate'] : 0;
+                $active = isset($row['is_active']) ? (int)$row['is_active'] : 1;
+                $stmt = $pdo->prepare("SELECT * FROM products WHERE firm_id=? AND sku=? LIMIT 1");
+                $stmt->execute([$firmId,$sku]);
+                if($existing = $stmt->fetch()) {
+                    $pdo->prepare("UPDATE products SET name=?, default_currency=?, base_price=?, vat_rate=?, is_active=? WHERE id=?")
+                        ->execute([$name,$currency,$base,$vat,$active,$existing['id']]);
+                    audit_log($pdo,$firmId,'product',(int)$existing['id'],'update',$existing,[
+                        'name'=>$name,'sku'=>$sku,'default_currency'=>$currency,'base_price'=>$base,'vat_rate'=>$vat,'is_active'=>$active]);
+                    $messages[]="Satır $line: güncellendi"; $success++;
+                } else {
+                    $pdo->prepare("INSERT INTO products (firm_id,name,sku,default_currency,base_price,vat_rate,is_active) VALUES (?,?,?,?,?,?,?)")
+                        ->execute([$firmId,$name,$sku,$currency,$base,$vat,$active]);
+                    $pid=(int)$pdo->lastInsertId();
+                    audit_log($pdo,$firmId,'product',$pid,'create',null,[
+                        'name'=>$name,'sku'=>$sku,'default_currency'=>$currency,'base_price'=>$base,'vat_rate'=>$vat,'is_active'=>$active]);
+                    $messages[]="Satır $line: eklendi"; $success++;
+                }
+            }
+        } else {
+            $messages[]='Geçerli bir CSV dosyası seçin'; $error++;
+        }
+    }
+    $_SESSION['import_messages']=$messages;
+    header('Location: '.($_SERVER['PHP_SELF']).($isAdmin?'?firm_id='.$firmId:''));
+    exit;
+}
+
+$countStmt = $pdo->prepare("SELECT COUNT(*) FROM products $where");
+$countStmt->execute($params);
+$total = (int)$countStmt->fetchColumn();
+$pagination = paginate($total,$page,$perPage);
+$listStmt = $pdo->prepare("SELECT * FROM products $where ORDER BY $sort $dir LIMIT :offset,:pp");
+foreach($params as $k=>$v) $listStmt->bindValue(':'.$k,$v);
+$listStmt->bindValue(':offset',$pagination['offset'],PDO::PARAM_INT);
+$listStmt->bindValue(':pp',$pagination['per_page'],PDO::PARAM_INT);
+$listStmt->execute();
+$products = $listStmt->fetchAll();
+
+$queryBase=['firm_id'=>$firmId,'search'=>$search,'sort'=>$sort,'dir'=>strtolower($dir),'per_page'=>$perPage,'active'=>$filterActive];
+include __DIR__.'/partials/header.php';
+if($sub['status']==='grace') echo '<div class="alert alert-warning sticky-top">Aboneliğiniz yenilenmek üzere; kritik işlemler devre dışıdır.</div>';
+if(isset($_SESSION['import_messages'])) { echo '<div class="alert alert-info"><ul class="mb-0">'; foreach($_SESSION['import_messages'] as $m) echo '<li>'.htmlspecialchars($m).'</li>'; echo '</ul></div>'; unset($_SESSION['import_messages']); }
+?>
+<div class="d-flex justify-content-between mb-3">
+    <form class="d-flex" method="get">
+        <?php if($isAdmin): ?>
+            <select name="firm_id" class="form-select me-2" onchange="this.form.submit()">
+                <?php foreach($firms as $f): ?><option value="<?php echo $f['id']; ?>" <?php if($f['id']==$firmId) echo 'selected'; ?>><?php echo htmlspecialchars($f['name']); ?></option><?php endforeach; ?>
+            </select>
+        <?php endif; ?>
+        <input type="search" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control me-2" placeholder="Ara">
+        <select name="active" class="form-select me-2" onchange="this.form.submit()">
+            <option value="all" <?php if($filterActive==='all') echo 'selected'; ?>>Tümü</option>
+            <option value="1" <?php if($filterActive==='1') echo 'selected'; ?>>Aktif</option>
+            <option value="0" <?php if($filterActive==='0') echo 'selected'; ?>>Pasif</option>
+        </select>
+        <select name="per_page" class="form-select me-2" onchange="this.form.submit()">
+            <?php foreach([10,25,50] as $n): ?><option value="<?php echo $n; ?>" <?php if($n==$perPage) echo 'selected'; ?>><?php echo $n; ?></option><?php endforeach; ?>
+        </select>
+        <button class="btn btn-outline-secondary" type="submit">Filtrele</button>
+    </form>
+    <div>
+        <a href="?<?php echo http_build_query(array_merge($queryBase,['export'=>1])); ?>" class="btn btn-success me-2">Dışa aktar (CSV)</a>
+        <button class="btn btn-primary" <?php if($sub['status']==='grace') echo 'disabled'; ?> onclick="location.href='product_add.php<?php echo $isAdmin?'?firm_id='.$firmId:''; ?>'">Ürün Ekle</button>
+    </div>
+</div>
+<form method="post" enctype="multipart/form-data" class="mb-3">
+    <?php echo csrf_field(); ?>
+    <div class="input-group">
+        <input type="file" name="csv" accept="text/csv" class="form-control" <?php if($sub['status']==='grace') echo 'disabled'; ?>>
+        <button class="btn btn-outline-secondary" name="import_csv" <?php if($sub['status']==='grace') echo 'disabled'; ?>>İçe aktar (CSV)</button>
+    </div>
+</form>
+<div class="table-responsive">
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'name','dir'=>$sort=='name' && $dir=='ASC'?'desc':'asc'])); ?>">Ad</a></th>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'sku','dir'=>$sort=='sku' && $dir=='ASC'?'desc':'asc'])); ?>">SKU</a></th>
+            <th>Para</th>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'base_price','dir'=>$sort=='base_price' && $dir=='ASC'?'desc':'asc'])); ?>">Fiyat</a></th>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'vat_rate','dir'=>$sort=='vat_rate' && $dir=='ASC'?'desc':'asc'])); ?>">KDV%</a></th>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'is_active','dir'=>$sort=='is_active' && $dir=='ASC'?'desc':'asc'])); ?>">Aktif</a></th>
+            <th><a href="?<?php echo http_build_query(array_merge($queryBase,['sort'=>'created_at','dir'=>$sort=='created_at' && $dir=='ASC'?'desc':'asc'])); ?>">Kayıt</a></th>
+            <th>İşlemler</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if(!$products): ?><tr><td colspan="8" class="text-center">Kayıt bulunamadı.</td></tr><?php else: foreach($products as $p): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($p['name']); ?></td>
+            <td><?php echo htmlspecialchars($p['sku']); ?></td>
+            <td><?php echo htmlspecialchars($p['default_currency']); ?></td>
+            <td><?php echo htmlspecialchars($p['base_price']); ?></td>
+            <td><?php echo htmlspecialchars($p['vat_rate']); ?></td>
+            <td><?php echo $p['is_active'] ? 'Evet' : 'Hayır'; ?></td>
+            <td><?php echo htmlspecialchars($p['created_at']); ?></td>
+            <td>
+                <a class="btn btn-sm btn-secondary" <?php if($sub['status']==='grace') echo 'disabled'; ?> href="product_edit.php?id=<?php echo $p['id']; ?>">Düzenle</a>
+                <form method="post" action="product_delete.php" class="d-inline" onsubmit="return confirm('Silinsin mi?');">
+                    <?php echo csrf_field(); ?>
+                    <input type="hidden" name="id" value="<?php echo $p['id']; ?>">
+                    <button class="btn btn-sm btn-danger" <?php if($sub['status']==='grace') echo 'disabled'; ?>>Sil</button>
+                </form>
+            </td>
+        </tr>
+    <?php endforeach; endif; ?>
+    </tbody>
+</table>
+</div>
+<?php echo pagination_links($pagination,$queryBase); ?>
+<?php include __DIR__.'/partials/footer.php'; ?>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,70 @@
+<?php
+require __DIR__.'/app/config/config.php';
+require __DIR__.'/app/config/csrf.php';
+session_start();
+if(isset($_SESSION['user_id'])) {
+    header('Location: /dashboard.php');
+    exit;
+}
+if($_SERVER['REQUEST_METHOD'] === 'POST') {
+    verify_csrf();
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $confirm = $_POST['password_confirm'] ?? '';
+    if($password !== $confirm) {
+        $_SESSION['flash']['danger'] = 'Parolalar eşleşmiyor';
+    } else {
+        $stmt = $pdo->prepare("SELECT id FROM users WHERE email = ? LIMIT 1");
+        $stmt->execute([$email]);
+        if($stmt->fetch()) {
+            $_SESSION['flash']['danger'] = 'Bu e-posta zaten kayıtlı';
+        } else {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $stmt = $pdo->prepare("INSERT INTO users (full_name,email,password_hash,role) VALUES (?,?,?,?)");
+            $stmt->execute([$name,$email,$hash,'firma']);
+            $user_id = $pdo->lastInsertId();
+            session_regenerate_id(true);
+            $_SESSION['user_id'] = $user_id;
+            $_SESSION['role'] = 'firma';
+            $_SESSION['name'] = $name;
+            $_SESSION['user'] = [
+                'id' => $user_id,
+                'role' => 'firma',
+                'full_name' => $name,
+                'firm_id' => null,
+                'firm_name' => null
+            ];
+            header('Location: /dashboard.php');
+            exit;
+        }
+    }
+}
+include __DIR__.'/partials/header.php';
+?>
+<div class="row justify-content-center">
+    <div class="col-md-4">
+        <form method="post" class="card p-4">
+            <h3 class="mb-3">Kayıt Ol</h3>
+            <?php echo csrf_field(); ?>
+            <div class="mb-3">
+                <label class="form-label">Ad Soyad</label>
+                <input type="text" name="name" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">E-posta</label>
+                <input type="email" name="email" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Parola</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Parola (Tekrar)</label>
+                <input type="password" name="password_confirm" class="form-control" required>
+            </div>
+            <button type="submit" class="btn btn-success w-100">Kayıt Ol</button>
+        </form>
+    </div>
+</div>
+<?php include __DIR__.'/partials/footer.php'; ?>


### PR DESCRIPTION
## Özellikler
- Müşteri ve ürün tabloları eklenerek çok kiracılı yapıya uyumlu CRUD akışları sağlandı
- Liste sayfalarında arama, sıralama, sayfalama ve CSV içe/dışa aktarma desteklendi
- Grace döneminde kritik işlemler devre dışı bırakılıp audit logları kaydedildi

## Kurulum
1. `app/sql/schema.sql` güncellenen şemayı mevcut veritabanınıza uygulayın.
2. Müşteri ve ürün modülleri için eklenen PHP dosyalarını kök dizinde barındırın.
3. Gerekli oturum ve veritabanı ayarlarını `.env` aracılığıyla sağlayın.


------
https://chatgpt.com/codex/tasks/task_e_689f5746127c833388559d9ef21b5900